### PR TITLE
Move tests out of __tests__ folders

### DIFF
--- a/jestconfig.json
+++ b/jestconfig.json
@@ -2,7 +2,7 @@
   "transform": {
     "^.+\\.(t|j)sx?$": "ts-jest"
   },
-  "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
-  "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"],
-  "collectCoverage": true
+  "testRegex": "/tests/.*\\.(test|spec)?\\.(ts|tsx)$",
+  "collectCoverage": true,
+  "collectCoverageFrom": ["src/**/*.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "lint": "tslint -p tsconfig.json",
-    "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
+    "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
     "test": "jest --config jestconfig.json",
     "build": "tsc",
     "prepare": "npm run build",

--- a/tests/tempo.test.ts
+++ b/tests/tempo.test.ts
@@ -1,4 +1,4 @@
-import TempoApi from '../tempo';
+import TempoApi from '../src/tempo';
 
 function getOptions(options?: any) {
   const actualOptions = options || {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,10 +3,13 @@
     "target": "es2015",
     "module": "commonjs",
     "declaration": true,
-    "outDir": "./lib",
+    "outDir": "lib",
     "strict": true,
     "sourceMap": true
   },
   "include": ["src"],
-  "exclude": ["node_modules", "**/__tests__/*"]
+  "exclude": [
+    "node_modules",
+    "tests"
+  ]
 }


### PR DESCRIPTION
Having `__tests__` directories looks ugly. This PR moves the tests into a different file entirely.