### PR TITLE
Move interfaces out of main file

### DIFF
--- a/src/queryOptions.ts
+++ b/src/queryOptions.ts
@@ -1,0 +1,17 @@
+export interface IStringMap {
+  [s: string]: string;
+}
+
+export interface IPaginationFrom extends IStringMap {
+  offset: string;
+  limit: string;
+}
+
+export interface IUpdatedFrom extends IStringMap {
+  updatedFrom: string;
+}
+
+export interface IDateRange extends IStringMap {
+  from: string;
+  to: string;
+}

--- a/src/queryOptions.ts
+++ b/src/queryOptions.ts
@@ -2,7 +2,7 @@ export interface IStringMap {
   [s: string]: string;
 }
 
-export interface IPaginationFrom extends IStringMap {
+export interface IPagination extends IStringMap {
   offset: string;
   limit: string;
 }

--- a/src/tempo.ts
+++ b/src/tempo.ts
@@ -1,5 +1,6 @@
 import * as request from 'request-promise';
 import * as url from 'url';
+import * as queryOptions from './queryOptions';
 
 interface ITempoApiOptions {
   port?: string;
@@ -11,24 +12,6 @@ interface ITempoApiOptions {
   intermediatePath?: string;
   bearerToken?: string;
   strictSSL?: boolean;
-}
-
-interface IStringMap {
-  [s: string]: string;
-}
-
-interface IPaginationFromQueryOptions extends IStringMap {
-  offset: string;
-  limit: string;
-}
-
-interface IUpdatedFromQueryOptions extends IStringMap {
-  updatedFrom: string;
-}
-
-interface IDateRangeQueryOptions extends IStringMap {
-  from: string;
-  to: string;
 }
 
 interface IRequestHeaderOptions {
@@ -88,9 +71,9 @@ export default class TempoApi {
   public async getWorklogsForUser(
     accountId: string,
     options?: Partial<
-      IDateRangeQueryOptions &
-        IUpdatedFromQueryOptions &
-        IPaginationFromQueryOptions
+      queryOptions.IDateRange &
+      queryOptions.IUpdatedFrom &
+      queryOptions.IPaginationFrom
     >
   ) {
     return await this.doRequest(

--- a/src/tempo.ts
+++ b/src/tempo.ts
@@ -73,7 +73,7 @@ export default class TempoApi {
     options?: Partial<
       queryOptions.IDateRange &
       queryOptions.IUpdatedFrom &
-      queryOptions.IPaginationFrom
+      queryOptions.IPagination
     >
   ) {
     return await this.doRequest(


### PR DESCRIPTION
`QueryOptions` are string-map interfaces that are passed as parameters into the getX methods in `tempo.ts`.

This PR moves the interfaces into a new class so it is not all together with the main `tempo.ts` file.