### PR TITLE
Split request handling code into different classes

### DIFF
--- a/src/request/handler.ts
+++ b/src/request/handler.ts
@@ -1,0 +1,117 @@
+import * as request from 'request-promise';
+import * as url from 'url';
+
+interface IHandlerOptions {
+  port?: string;
+  request?: request.RequestPromiseAPI;
+  timeout?: number;
+  protocol: string;
+  host: string;
+  apiVersion: string;
+  intermediatePath?: string;
+  bearerToken?: string;
+  strictSSL?: boolean;
+}
+
+interface IRequestHeaderOptions {
+  method?: string;
+}
+
+interface IUriOptions {
+  pathname: string;
+  query?: Partial<{ [key: string]: string }>;
+  intermediatePath?: string;
+}
+
+interface IRequestBaseOptions {
+  timeout?: number;
+  auth?: any;
+}
+
+export default class Handler {
+  public readonly protocol: string;
+  public readonly port?: string;
+  public readonly host: string;
+  public readonly apiVersion: string;
+  public readonly bearerToken?: string;
+  public readonly intermediatePath?: string;
+  public readonly strictSSL: boolean;
+  public readonly request: request.RequestPromiseAPI;
+  public readonly baseOptions: {
+    timeout?: number;
+    auth?: any;
+  };
+
+  public constructor(options: IHandlerOptions) {
+    this.protocol = options.protocol || 'https';
+    this.intermediatePath = options.intermediatePath;
+    this.strictSSL =
+      options.hasOwnProperty('strictSSL') &&
+      typeof options.strictSSL === 'boolean'
+        ? options.strictSSL
+        : true;
+    this.port = options.port;
+    this.host = options.host;
+    this.apiVersion = options.apiVersion;
+    this.bearerToken = options.bearerToken;
+    this.request = options.request || request; // To mock requests
+    this.baseOptions = {};
+
+    if (this.bearerToken) {
+      this.baseOptions.auth = {
+        bearer: this.bearerToken,
+        pass: '',
+        sendImmediately: true,
+        user: ''
+      };
+    }
+
+    if (options.timeout) {
+      this.baseOptions.timeout = options.timeout;
+    }
+  }
+
+  public async doRequest(requestOptions: any) {
+    const options = {
+      ...this.baseOptions,
+      ...requestOptions
+    };
+
+    const response = await this.request(options);
+
+    if (response) {
+      if (
+        Array.isArray(response.errorMessages) &&
+        response.errorMessages.length > 0
+      ) {
+        throw new Error(response.errorMessages.join(', '));
+      }
+    }
+
+    return response;
+  }
+
+  public makeRequestHeader(uri: string, options: IRequestHeaderOptions = {}) {
+    return {
+      json: true,
+      method: options.method || 'GET',
+      rejectUnauthorized: this.strictSSL,
+      uri,
+      ...options
+    };
+  }
+
+  public makeUri({ pathname, query, intermediatePath }: IUriOptions) {
+    const intermediateToUse = this.intermediatePath || intermediatePath;
+    const tempPath = intermediateToUse || `/core/${this.apiVersion}`;
+    const uri = url.format({
+      hostname: this.host,
+      pathname: `${tempPath}${pathname}`,
+      port: this.port,
+      protocol: this.protocol,
+      query
+    });
+
+    return decodeURIComponent(uri);
+  }
+}

--- a/src/tempo.ts
+++ b/src/tempo.ts
@@ -1,8 +1,9 @@
 import * as request from 'request-promise';
-import * as url from 'url';
 import * as queryOptions from './queryOptions';
+import RequestHandler from './request/handler';
 
 interface ITempoApiOptions {
+  requestHandler?: RequestHandler;
   port?: string;
   request?: request.RequestPromiseAPI;
   timeout?: number;
@@ -14,57 +15,11 @@ interface ITempoApiOptions {
   strictSSL?: boolean;
 }
 
-interface IRequestHeaderOptions {
-  method?: string;
-}
-
-interface IUriOptions {
-  pathname: string;
-  query?: Partial<{ [key: string]: string }>;
-  intermediatePath?: string;
-}
-
 export default class TempoApi {
-  public readonly protocol: string;
-  public readonly port?: string;
-  public readonly host: string;
-  public readonly apiVersion: string;
-  public readonly bearerToken?: string;
-  public readonly intermediatePath?: string;
-  public readonly strictSSL: boolean;
-  public readonly request: request.RequestPromiseAPI;
-  public readonly baseOptions: {
-    timeout?: number;
-    auth?: any;
-  };
+  private readonly requestHandler: RequestHandler;
 
   constructor(options: ITempoApiOptions) {
-    this.protocol = options.protocol || 'https';
-    this.intermediatePath = options.intermediatePath;
-    this.strictSSL =
-      options.hasOwnProperty('strictSSL') &&
-      typeof options.strictSSL === 'boolean'
-        ? options.strictSSL
-        : true;
-    this.port = options.port;
-    this.host = options.host;
-    this.apiVersion = options.apiVersion;
-    this.bearerToken = options.bearerToken;
-    this.request = options.request || request; // To mock requests
-    this.baseOptions = {};
-
-    if (this.bearerToken) {
-      this.baseOptions.auth = {
-        bearer: this.bearerToken,
-        pass: '',
-        sendImmediately: true,
-        user: ''
-      };
-    }
-
-    if (options.timeout) {
-      this.baseOptions.timeout = options.timeout;
-    }
+    this.requestHandler = options.requestHandler || new RequestHandler(options);
   }
 
   public async getWorklogsForUser(
@@ -75,57 +30,13 @@ export default class TempoApi {
         queryOptions.IPagination
     >
   ) {
-    return await this.doRequest(
-      this.makeRequestHeader(
-        this.makeUri({
+    return await this.requestHandler.doRequest(
+      this.requestHandler.makeRequestHeader(
+        this.requestHandler.makeUri({
           pathname: `/worklogs/user/${accountId}`,
           query: options
         })
       )
     );
-  }
-
-  private async doRequest(requestOptions: any) {
-    const options = {
-      ...this.baseOptions,
-      ...requestOptions
-    };
-
-    const response = await this.request(options);
-
-    if (response) {
-      if (
-        Array.isArray(response.errorMessages) &&
-        response.errorMessages.length > 0
-      ) {
-        throw new Error(response.errorMessages.join(', '));
-      }
-    }
-
-    return response;
-  }
-
-  private makeRequestHeader(uri: string, options: IRequestHeaderOptions = {}) {
-    return {
-      json: true,
-      method: options.method || 'GET',
-      rejectUnauthorized: this.strictSSL,
-      uri,
-      ...options
-    };
-  }
-
-  private makeUri({ pathname, query, intermediatePath }: IUriOptions) {
-    const intermediateToUse = this.intermediatePath || intermediatePath;
-    const tempPath = intermediateToUse || `/core/${this.apiVersion}`;
-    const uri = url.format({
-      hostname: this.host,
-      pathname: `${tempPath}${pathname}`,
-      port: this.port,
-      protocol: this.protocol,
-      query
-    });
-
-    return decodeURIComponent(uri);
   }
 }

--- a/tests/request/handler.test.ts
+++ b/tests/request/handler.test.ts
@@ -1,0 +1,40 @@
+import requestHandler from '../../src/request/handler';
+
+function getOptions(options?: any) {
+  const actualOptions = options || {};
+  return {
+    apiVersion: actualOptions.apiVersion || '3',
+    bearerToken: actualOptions.bearer || 'sometoken',
+    ca: actualOptions.ca || null,
+    host: actualOptions.host || 'tempo.somehost.com',
+    intermediatePath: actualOptions.intermediatePath,
+    port: actualOptions.port || '8080',
+    protocol: actualOptions.protocol || 'http',
+    request: actualOptions.request,
+    strictSSL: actualOptions.hasOwnProperty('strictSSL')
+      ? actualOptions.strictSSL
+      : true,
+    timeout: actualOptions.timeout || null
+  };
+}
+
+describe('TempoAi', () => {
+  describe('Constructor Tests', () => {
+    it('Constructor functions properly', () => {
+      const tempo = new requestHandler(
+        getOptions({
+          timeout: 3000
+        })
+      );
+
+      expect(tempo.protocol).toEqual('http');
+      expect(tempo.host).toEqual('tempo.somehost.com');
+      expect(tempo.port).toEqual('8080');
+      expect(tempo.baseOptions.auth.user).toEqual('');
+      expect(tempo.baseOptions.auth.pass).toEqual('');
+      expect(tempo.baseOptions.auth.bearer).toEqual('sometoken');
+      expect(tempo.baseOptions.timeout).toEqual(3000);
+      expect(tempo.apiVersion).toEqual('3');
+    });
+  });
+});

--- a/tests/tempo.test.ts
+++ b/tests/tempo.test.ts
@@ -19,25 +19,6 @@ function getOptions(options?: any) {
 }
 
 describe('TempoAi', () => {
-  describe('Constructor Tests', () => {
-    it('Constructor functions properly', () => {
-      const tempo = new TempoApi(
-        getOptions({
-          timeout: 3000
-        })
-      );
-
-      expect(tempo.protocol).toEqual('http');
-      expect(tempo.host).toEqual('tempo.somehost.com');
-      expect(tempo.port).toEqual('8080');
-      expect(tempo.baseOptions.auth.user).toEqual('');
-      expect(tempo.baseOptions.auth.pass).toEqual('');
-      expect(tempo.baseOptions.auth.bearer).toEqual('sometoken');
-      expect(tempo.baseOptions.timeout).toEqual(3000);
-      expect(tempo.apiVersion).toEqual('3');
-    });
-  });
-
   describe('Request Functions Tests', () => {
     async function dummyURLCall(
       tempoApiMethodName: string,


### PR DESCRIPTION
As this project grows larger, having all the request logic in the tempoApi class doesn't seem appropriate.

This PR moves all the request handling into a different class entirely.