### PR TITLE
Split Worklogs Collections out of TempoApi class

### DIFF
--- a/src/collections/worklogs.ts
+++ b/src/collections/worklogs.ts
@@ -1,0 +1,165 @@
+import * as queryOptions from '../queryOptions';
+import RequestHandler from '../request/handler';
+
+export interface IQueryOptionIssue {
+  issue: string[];
+}
+
+export default class Worklogs {
+  private requestHandler: RequestHandler;
+
+  constructor(requestHandler: RequestHandler) {
+    this.requestHandler = requestHandler;
+  }
+
+  public async get(
+    options?: Partial<
+      IQueryOptionIssue &
+        queryOptions.IDateRange &
+        queryOptions.IUpdatedFrom &
+        queryOptions.IPagination
+    >
+  ) {
+    return await this.requestHandler.doRequest(
+      this.requestHandler.makeRequestHeader(
+        this.requestHandler.makeUri({
+          pathname: `/worklogs`,
+          query: options
+        })
+      )
+    );
+  }
+
+  public async getWorklog(worklogId: string) {
+    return await this.requestHandler.doRequest(
+      this.requestHandler.makeRequestHeader(
+        this.requestHandler.makeUri({
+          pathname: `/worklogs/${worklogId}`
+        })
+      )
+    );
+  }
+
+  public async getWorklogWorkAttributeValues(worklogId: string) {
+    return await this.requestHandler.doRequest(
+      this.requestHandler.makeRequestHeader(
+        this.requestHandler.makeUri({
+          pathname: `/worklogs/${worklogId}/work-attribute-values`
+        })
+      )
+    );
+  }
+
+  public async getWorklogWorkAttributeValuesByKey(
+    worklogId: string,
+    key: string
+  ) {
+    return await this.requestHandler.doRequest(
+      this.requestHandler.makeRequestHeader(
+        this.requestHandler.makeUri({
+          pathname: `/worklogs/${worklogId}/work-attribute-values/${key}`
+        })
+      )
+    );
+  }
+
+  public async getForJiraWorklog(jiraWorklogId: string) {
+    return await this.requestHandler.doRequest(
+      this.requestHandler.makeRequestHeader(
+        this.requestHandler.makeUri({
+          pathname: `/worklogs/jira/${jiraWorklogId}`
+        })
+      )
+    );
+  }
+
+  public async getForJiraFilter(
+    jiraFilterId: string,
+    options?: Partial<
+      queryOptions.IDateRange &
+        queryOptions.IUpdatedFrom &
+        queryOptions.IPagination
+    >
+  ) {
+    return await this.requestHandler.doRequest(
+      this.requestHandler.makeRequestHeader(
+        this.requestHandler.makeUri({
+          pathname: `/worklogs/jira/filter/${jiraFilterId}`,
+          query: options
+        })
+      )
+    );
+  }
+
+  public async getForAccount(
+    accountKey: string,
+    options?: Partial<
+      queryOptions.IDateRange &
+        queryOptions.IUpdatedFrom &
+        queryOptions.IPagination
+    >
+  ) {
+    return await this.requestHandler.doRequest(
+      this.requestHandler.makeRequestHeader(
+        this.requestHandler.makeUri({
+          pathname: `/worklogs/account/${accountKey}`,
+          query: options
+        })
+      )
+    );
+  }
+
+  public async getForProject(
+    projectKey: string,
+    options?: Partial<
+      queryOptions.IDateRange &
+        queryOptions.IUpdatedFrom &
+        queryOptions.IPagination
+    >
+  ) {
+    return await this.requestHandler.doRequest(
+      this.requestHandler.makeRequestHeader(
+        this.requestHandler.makeUri({
+          pathname: `/worklogs/project/${projectKey}`,
+          query: options
+        })
+      )
+    );
+  }
+
+  public async getForTeam(
+    teamId: string,
+    options?: Partial<
+      queryOptions.IDateRange &
+        queryOptions.IUpdatedFrom &
+        queryOptions.IPagination
+    >
+  ) {
+    return await this.requestHandler.doRequest(
+      this.requestHandler.makeRequestHeader(
+        this.requestHandler.makeUri({
+          pathname: `/worklogs/team/${teamId}`,
+          query: options
+        })
+      )
+    );
+  }
+
+  public async getForUser(
+    accountId: string,
+    options?: Partial<
+      queryOptions.IDateRange &
+        queryOptions.IUpdatedFrom &
+        queryOptions.IPagination
+    >
+  ) {
+    return await this.requestHandler.doRequest(
+      this.requestHandler.makeRequestHeader(
+        this.requestHandler.makeUri({
+          pathname: `/worklogs/user/${accountId}`,
+          query: options
+        })
+      )
+    );
+  }
+}

--- a/src/tempo.ts
+++ b/src/tempo.ts
@@ -1,8 +1,8 @@
 import * as request from 'request-promise';
-import * as queryOptions from './queryOptions';
+import Worklogs from './collections/worklogs';
 import RequestHandler from './request/handler';
 
-interface ITempoApiOptions {
+export interface ITempoApiOptions {
   requestHandler?: RequestHandler;
   port?: string;
   request?: request.RequestPromiseAPI;
@@ -16,27 +16,11 @@ interface ITempoApiOptions {
 }
 
 export default class TempoApi {
+  public readonly worklogs: Worklogs;
   private readonly requestHandler: RequestHandler;
 
   constructor(options: ITempoApiOptions) {
     this.requestHandler = options.requestHandler || new RequestHandler(options);
-  }
-
-  public async getWorklogsForUser(
-    accountId: string,
-    options?: Partial<
-      queryOptions.IDateRange &
-        queryOptions.IUpdatedFrom &
-        queryOptions.IPagination
-    >
-  ) {
-    return await this.requestHandler.doRequest(
-      this.requestHandler.makeRequestHeader(
-        this.requestHandler.makeUri({
-          pathname: `/worklogs/user/${accountId}`,
-          query: options
-        })
-      )
-    );
+    this.worklogs = new Worklogs(this.requestHandler);
   }
 }

--- a/tests/collections/worklogs.test.ts
+++ b/tests/collections/worklogs.test.ts
@@ -1,0 +1,164 @@
+import RequestHandler from '../../src/request/handler';
+import Worklogs from '../../src/collections/worklogs';
+
+function getOptions(options?: any) {
+  const actualOptions = options || {};
+  return {
+    apiVersion: actualOptions.apiVersion || '3',
+    bearerToken: actualOptions.bearer || 'sometoken',
+    ca: actualOptions.ca || null,
+    host: actualOptions.host || 'tempo.somehost.com',
+    intermediatePath: actualOptions.intermediatePath,
+    port: actualOptions.port || '8080',
+    protocol: actualOptions.protocol || 'http',
+    request: actualOptions.request,
+    strictSSL: actualOptions.hasOwnProperty('strictSSL')
+      ? actualOptions.strictSSL
+      : true,
+    timeout: actualOptions.timeout || null
+  };
+}
+
+describe('TempoAi', () => {
+  describe('Request Functions Tests', () => {
+    async function dummyURLCall(
+      tempoApiMethodName: string,
+      functionArguments: any,
+      dummyRequestMethod?: any,
+      returnedValue = 'uri'
+    ) {
+      let dummyRequest = dummyRequestMethod;
+      if (!dummyRequest) {
+        dummyRequest = async (requestOptions: any) => requestOptions;
+      }
+
+      const requestHandler = new RequestHandler(
+        getOptions({
+          request: dummyRequest
+        })
+      );
+
+      const collection = new Worklogs(requestHandler);
+
+      // @ts-ignore
+      const resultObject = await collection[tempoApiMethodName].apply(
+        collection,
+        functionArguments
+      );
+
+      // hack exposing the qs object as the query string in the URL so this is
+      // uniformly testable
+      if (resultObject.qs) {
+        const queryString = Object.keys(resultObject.qs)
+          .map(x => `${x}=${resultObject.qs[x]}`)
+          .join('&');
+        return `${resultObject.uri}?${queryString}`;
+      }
+
+      return resultObject[returnedValue];
+    }
+
+    it('get hits proper url', async () => {
+      const result = await dummyURLCall('get', []);
+      expect(result).toEqual('http://tempo.somehost.com:8080/core/3/worklogs');
+    });
+
+    it('getWorklog hits proper url', async () => {
+      const result = await dummyURLCall('getWorklog', ['someWorklogId']);
+      expect(result).toEqual(
+        'http://tempo.somehost.com:8080/core/3/worklogs/someWorklogId'
+      );
+    });
+
+    it('getWorklogWorkAttributeValues hits proper url', async () => {
+      const result = await dummyURLCall('getWorklogWorkAttributeValues', [
+        'someWorklogId'
+      ]);
+      expect(result).toEqual(
+        'http://tempo.somehost.com:8080/core/3/worklogs/someWorklogId/work-attribute-values'
+      );
+    });
+
+    it('getWorklogWorkAttributeValuesByKey hits proper url', async () => {
+      const result = await dummyURLCall('getWorklogWorkAttributeValuesByKey', [
+        'someWorklogId',
+        'someKey'
+      ]);
+      expect(result).toEqual(
+        'http://tempo.somehost.com:8080/core/3/worklogs/someWorklogId/work-attribute-values/someKey'
+      );
+    });
+
+    it('getForJiraWorklog hits proper url', async () => {
+      const result = await dummyURLCall('getForJiraWorklog', [
+        'someJiraWorklogId'
+      ]);
+      expect(result).toEqual(
+        'http://tempo.somehost.com:8080/core/3/worklogs/jira/someJiraWorklogId'
+      );
+    });
+
+    it('getForJiraFilter hits proper url', async () => {
+      const result = await dummyURLCall('getForJiraFilter', [
+        'someJiraFilterId'
+      ]);
+      expect(result).toEqual(
+        'http://tempo.somehost.com:8080/core/3/worklogs/jira/filter/someJiraFilterId'
+      );
+    });
+
+    it('getForAccount hits proper url', async () => {
+      const result = await dummyURLCall('getForAccount', ['someAccountKey']);
+      expect(result).toEqual(
+        'http://tempo.somehost.com:8080/core/3/worklogs/account/someAccountKey'
+      );
+    });
+
+    it('getForProject hits proper url', async () => {
+      const result = await dummyURLCall('getForProject', ['someProjectKey']);
+      expect(result).toEqual(
+        'http://tempo.somehost.com:8080/core/3/worklogs/project/someProjectKey'
+      );
+    });
+
+    it('getForTeam hits proper url', async () => {
+      const result = await dummyURLCall('getForTeam', ['someTeamId']);
+      expect(result).toEqual(
+        'http://tempo.somehost.com:8080/core/3/worklogs/team/someTeamId'
+      );
+    });
+
+    it('getForUser hits proper url', async () => {
+      const result = await dummyURLCall('getForUser', ['someAccountId']);
+      expect(result).toEqual(
+        'http://tempo.somehost.com:8080/core/3/worklogs/user/someAccountId'
+      );
+    });
+  });
+
+  describe('Requests Error Tests', () => {
+    it('Mocked error messages throws errors', async () => {
+      expect.assertions(1);
+      const mockRequest = async (requestOptions: any) => {
+        return {
+          requestOptions,
+          errorMessages: ['Something is clearly wrong!']
+        };
+      };
+
+      const requestHandler = new RequestHandler(
+        getOptions({
+          request: mockRequest
+        })
+      );
+
+      const collection = new Worklogs(requestHandler);
+
+      try {
+        await collection.getForUser('someAccountId');
+      } catch (e) {
+        expect(e.message).toMatch('Something is clearly wrong!');
+      }
+    });
+  });
+});

--- a/tests/tempo.test.ts
+++ b/tests/tempo.test.ts
@@ -1,6 +1,6 @@
 import TempoApi from '../src/tempo';
 
-function getOptions(options?: any) {
+function getMockOptions(options?: any) {
   const actualOptions = options || {};
   return {
     apiVersion: actualOptions.apiVersion || '3',
@@ -18,74 +18,20 @@ function getOptions(options?: any) {
   };
 }
 
-describe('TempoAi', () => {
-  describe('Request Functions Tests', () => {
-    async function dummyURLCall(
-      tempoApiMethodName: string,
-      functionArguments: any,
-      dummyRequestMethod?: any,
-      returnedValue = 'uri'
-    ) {
-      let dummyRequest = dummyRequestMethod;
-      if (!dummyRequest) {
-        dummyRequest = async (requestOptions: any) => requestOptions;
-      }
+describe('TempoApi', () => {
+  describe('Collections can be accessed', () => {
+    it('Expect mocked data to be returned', async () => {
+      const dummtApiResponse = { someSample: '...data to expect!' };
 
+      const dummyRequest = async () => dummtApiResponse;
       const tempo = new TempoApi(
-        getOptions({
+        getMockOptions({
           request: dummyRequest
         })
       );
 
-      // @ts-ignore
-      const resultObject = await tempo[tempoApiMethodName].apply(
-        tempo,
-        functionArguments
-      );
-
-      // hack exposing the qs object as the query string in the URL so this is
-      // uniformly testable
-      if (resultObject.qs) {
-        const queryString = Object.keys(resultObject.qs)
-          .map(x => `${x}=${resultObject.qs[x]}`)
-          .join('&');
-        return `${resultObject.uri}?${queryString}`;
-      }
-
-      return resultObject[returnedValue];
-    }
-
-    it('getWorklogsForUser hits proper url', async () => {
-      const result = await dummyURLCall('getWorklogsForUser', [
-        'someAccountId'
-      ]);
-      expect(result).toEqual(
-        'http://tempo.somehost.com:8080/core/3/worklogs/user/someAccountId'
-      );
-    });
-  });
-
-  describe('Requests Error Tests', () => {
-    it('Mocked error messages throws errors', async () => {
-      expect.assertions(1);
-      const mockRequest = async (requestOptions: any) => {
-        return {
-          requestOptions,
-          errorMessages: ['Something is clearly wrong!']
-        };
-      };
-
-      const tempo = new TempoApi(
-        getOptions({
-          request: mockRequest
-        })
-      );
-
-      try {
-        await tempo.getWorklogsForUser('someAccountId');
-      } catch (e) {
-        expect(e.message).toMatch('Something is clearly wrong!');
-      }
+      const result = await tempo.worklogs.get();
+      expect(result).toBe(dummtApiResponse);
     });
   });
 });


### PR DESCRIPTION
**Note:** This is a breaking change.

This PR moves all "worklogs" functionality into a different class called `Worklogs`. In other words:

```js
await tempoClient.getWorklogsForUser(accountId)

// is now...

await tempoClient.worklogs.getForUser(accountId)
```

This is done because the tempo API has quite a lot of collections (or endpoints), and combining all collections into one file would make things difficult to maintain.

This PR also _adds_ all the `get` methods in Tempo's API for the worklogs collection. Other methods (`POST`, `PUT`, `DELETE`) will be added soon.