### PR TITLE
Fix error handling + Add more tests

### DIFF
--- a/src/request/handler.ts
+++ b/src/request/handler.ts
@@ -68,11 +68,15 @@ export default class Handler {
     const response = await this.request(options);
 
     if (response) {
-      if (
-        Array.isArray(response.errorMessages) &&
-        response.errorMessages.length > 0
-      ) {
-        throw new Error(response.errorMessages.join(', '));
+      if (Array.isArray(response.errors)) {
+        if (response.errors.length > 0) {
+          const messages = response.errors.map(
+            (error: { message: string }) => error.message
+          );
+          throw new Error(messages.join(', '));
+        } else {
+          throw new Error('Unknown error');
+        }
       }
     }
 

--- a/tests/collections/worklogs.test.ts
+++ b/tests/collections/worklogs.test.ts
@@ -59,7 +59,20 @@ describe('TempoAi', () => {
 
     it('get hits proper url', async () => {
       const result = await dummyURLCall('get', []);
-      expect(result.uri).toEqual('http://tempo.somehost.com:8080/core/3/worklogs');
+      expect(result.uri).toEqual(
+        'http://tempo.somehost.com:8080/core/3/worklogs'
+      );
+    });
+
+    it('get hits proper url with array of issues to lookup', async () => {
+      const result = await dummyURLCall('get', [
+        {
+          issue: ['someIssueA', 'someIssueB']
+        }
+      ]);
+      expect(result.uri).toEqual(
+        'http://tempo.somehost.com:8080/core/3/worklogs?issue=someIssueA&issue=someIssueB'
+      );
     });
 
     it('getWorklog hits proper url', async () => {
@@ -155,8 +168,7 @@ describe('TempoAi', () => {
       expect.assertions(1);
       const mockRequest = async (requestOptions: any) => {
         return {
-          requestOptions,
-          errorMessages: ['Something is clearly wrong!']
+          errors: [{ message: 'Something is clearly wrong!' }]
         };
       };
 

--- a/tests/request/handler.test.ts
+++ b/tests/request/handler.test.ts
@@ -91,21 +91,23 @@ describe('TempoAi', () => {
       expect(mockResponse).toEqual(undefined);
     });
 
-    it('Throws no error if error messages length is 0', async () => {
+    it('Throws unknown error if error messages length is 0', async () => {
+      expect.assertions(1);
       const handler = new requestHandler(
         getOptions({
           request: async () => {
             return {
-              errorMessages: []
+              errors: []
             };
           }
         })
       );
 
-      const mockResponse = await handler.doRequest({
-        uri: 'https://example.com'
-      });
-      expect(mockResponse).toEqual({ errorMessages: [] });
+      try {
+        await handler.doRequest({ uri: 'https://example.com' });
+      } catch (e) {
+        expect(e.message).toMatch('Unknown error');
+      }
     });
 
     it('Throws error if error messages length is at least 1', async () => {
@@ -114,7 +116,7 @@ describe('TempoAi', () => {
         getOptions({
           request: async () => {
             return {
-              errorMessages: ['Something went wrong!']
+              errors: [{ message: 'Something went wrong!' }]
             };
           }
         })


### PR DESCRIPTION
Errors messages from Tempo's API are different from JIRA's. This PR changes the error handling to match what we expect.

Some more tests were also added to make sure things like query arrays are handled properly