### PR TITLE
Change request-promise to axios + Decoupling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -433,18 +433,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/bluebird": {
-      "version": "3.5.27",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.27.tgz",
-      "integrity": "sha512-6BmYWSBea18+tSjjSC3QIyV93ZKAeNWGM7R6aYt1ryTZXrlHF+QLV0G2yV0viEGVyRkyQsWfMoJ0k/YghBX5sQ==",
-      "dev": true
-    },
-    "@types/caseless": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
-      "dev": true
-    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -497,51 +485,10 @@
       "integrity": "sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw==",
       "dev": true
     },
-    "@types/request": {
-      "version": "2.48.3",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.3.tgz",
-      "integrity": "sha512-3Wo2jNYwqgXcIz/rrq18AdOZUQB8cQ34CXZo+LUwPJNpvRAL86+Kc2wwI8mqpz9Cr1V+enIox5v+WZhy/p3h8w==",
-      "dev": true,
-      "requires": {
-        "@types/caseless": "*",
-        "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "form-data": "^2.5.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
-    },
-    "@types/request-promise": {
-      "version": "4.1.44",
-      "resolved": "https://registry.npmjs.org/@types/request-promise/-/request-promise-4.1.44.tgz",
-      "integrity": "sha512-RId7eFsUKxfal1LirDDIcOp9u3MM3NXFDBcC3sqIMcmu7f4U6DsCEMD8RbLZtnPrQlN5Jc79di/WPsIEDO4keg==",
-      "dev": true,
-      "requires": {
-        "@types/bluebird": "*",
-        "@types/request": "*"
-      }
-    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
-      "dev": true
-    },
-    "@types/tough-cookie": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
-      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
       "dev": true
     },
     "@types/yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2380,9 +2380,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
+      "integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -5036,9 +5036,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz",
-      "integrity": "sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==",
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -749,6 +749,22 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+        }
+      }
+    },
     "babel-jest": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
@@ -873,11 +889,6 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
-    },
-    "bluebird": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.0.tgz",
-      "integrity": "sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1683,6 +1694,24 @@
       "dev": true,
       "requires": {
         "locate-path": "^3.0.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "for-in": {
@@ -3465,7 +3494,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -3638,8 +3668,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nan": {
       "version": "2.14.0",
@@ -4055,7 +4084,8 @@
     "psl": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
+      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
+      "dev": true
     },
     "pump": {
       "version": "3.0.0",
@@ -4070,7 +4100,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "qs": {
       "version": "6.5.2",
@@ -4197,21 +4228,11 @@
         }
       }
     },
-    "request-promise": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.4.tgz",
-      "integrity": "sha512-8wgMrvE546PzbR5WbYxUQogUnUDfM0S7QIFZMID+J73vdFARkFy+HElj4T+MWYhpXwlLp0EQ8Zoj8xUA0he4Vg==",
-      "requires": {
-        "bluebird": "^3.5.0",
-        "request-promise-core": "1.1.2",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      }
-    },
     "request-promise-core": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
       "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.11"
       }
@@ -4669,7 +4690,8 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
     },
     "string-length": {
       "version": "2.0.0",
@@ -4852,6 +4874,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "typescript": "^3.6.3"
   },
   "dependencies": {
-    "request-promise": "^4.2.4"
+    "axios": "^0.19.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "devDependencies": {
     "@types/jest": "^24.0.18",
     "@types/node": "^12.7.11",
-    "@types/request-promise": "^4.1.44",
     "codecov": "^3.6.1",
     "jest": "^24.9.0",
     "prettier": "^1.18.2",

--- a/src/collections/abstractCollection.ts
+++ b/src/collections/abstractCollection.ts
@@ -1,10 +1,19 @@
-import { Method } from 'axios';
+import RequestBuilder from '../request/builder';
 import RequestHandler from '../request/handler';
+import { Method } from '../request/iRequestConfig';
 
 export default abstract class Collection {
+  protected requestBuilder: RequestBuilder;
   protected requestHandler: RequestHandler;
 
-  constructor(requestHandler: RequestHandler) {
+  constructor({
+    requestBuilder,
+    requestHandler
+  }: {
+    requestBuilder: RequestBuilder;
+    requestHandler: RequestHandler;
+  }) {
+    this.requestBuilder = requestBuilder;
     this.requestHandler = requestHandler;
   }
 
@@ -21,13 +30,13 @@ export default abstract class Collection {
     } = {}
   ): Promise<any> {
     return await this.requestHandler.doRequest(
-      this.requestHandler.makeRequestHeader(
-        this.requestHandler.makeUri({
+      this.requestBuilder.buildRequestConfig(
+        this.requestBuilder.buildUrl({
           pathname,
           query
         }),
         {
-          data: body,
+          body,
           method: method || 'GET'
         }
       )

--- a/src/collections/abstractCollection.ts
+++ b/src/collections/abstractCollection.ts
@@ -1,3 +1,4 @@
+import { Method } from 'axios';
 import RequestHandler from '../request/handler';
 
 export default abstract class Collection {
@@ -15,7 +16,7 @@ export default abstract class Collection {
       body
     }: {
       query?: Partial<{ [key: string]: string }>;
-      method?: string;
+      method?: Method;
       body?: any;
     } = {}
   ): Promise<any> {
@@ -26,8 +27,8 @@ export default abstract class Collection {
           query
         }),
         {
-          body,
-          method
+          data: body,
+          method: method || 'GET'
         }
       )
     );

--- a/src/request/axiosHttpClient.ts
+++ b/src/request/axiosHttpClient.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import { IHttpClient } from './iHttpClient';
+import { IRequestConfig } from './iRequestConfig';
+
+const axiosHttpClient: IHttpClient = async (requestConfig: IRequestConfig) => {
+  const response = await axios({
+    adapter: requestConfig.adapter,
+    data: requestConfig.body,
+    headers: requestConfig.headers,
+    method: requestConfig.method,
+    timeout: requestConfig.timeout,
+    url: requestConfig.url
+  });
+  return response.data;
+};
+
+export default axiosHttpClient;

--- a/src/request/builder.ts
+++ b/src/request/builder.ts
@@ -22,7 +22,6 @@ export default class Builder {
   public readonly port?: string;
   public readonly host: string;
   public readonly apiVersion: string;
-  public readonly bearerToken?: string;
   public readonly intermediatePath?: string;
   public readonly baseOptions: IRequestBaseConfig;
 
@@ -32,12 +31,11 @@ export default class Builder {
     this.port = options.port;
     this.host = options.host;
     this.apiVersion = options.apiVersion;
-    this.bearerToken = options.bearerToken;
     this.baseOptions = {};
 
-    if (this.bearerToken) {
+    if (options.bearerToken) {
       this.baseOptions.headers = {
-        Authorization: `Bearer ${this.bearerToken}`
+        Authorization: `Bearer ${options.bearerToken}`
       };
     }
 

--- a/src/request/builder.ts
+++ b/src/request/builder.ts
@@ -1,0 +1,74 @@
+import * as urlUtil from 'url';
+import { IRequestBaseConfig, IRequestConfig, Method } from './iRequestConfig';
+
+interface IRequestBuilderConfig {
+  port?: string;
+  timeout?: number;
+  protocol: string;
+  host: string;
+  apiVersion: string;
+  intermediatePath?: string;
+  bearerToken?: string;
+}
+
+interface IUrlOptions {
+  pathname: string;
+  query?: Partial<{ [key: string]: string }>;
+  intermediatePath?: string;
+}
+
+export default class Builder {
+  public readonly protocol: string;
+  public readonly port?: string;
+  public readonly host: string;
+  public readonly apiVersion: string;
+  public readonly bearerToken?: string;
+  public readonly intermediatePath?: string;
+  public readonly baseOptions: IRequestBaseConfig;
+
+  public constructor(options: IRequestBuilderConfig) {
+    this.protocol = options.protocol || 'https';
+    this.intermediatePath = options.intermediatePath;
+    this.port = options.port;
+    this.host = options.host;
+    this.apiVersion = options.apiVersion;
+    this.bearerToken = options.bearerToken;
+    this.baseOptions = {};
+
+    if (this.bearerToken) {
+      this.baseOptions.headers = {
+        Authorization: `Bearer ${this.bearerToken}`
+      };
+    }
+
+    if (options.timeout) {
+      this.baseOptions.timeout = options.timeout;
+    }
+  }
+
+  public buildRequestConfig(
+    url: string,
+    { method, body }: { method?: Method; body?: any } = {}
+  ): IRequestConfig {
+    return {
+      body,
+      method: method || 'GET',
+      url,
+      ...this.baseOptions
+    };
+  }
+
+  public buildUrl({ pathname, query, intermediatePath }: IUrlOptions) {
+    const intermediateToUse = this.intermediatePath || intermediatePath;
+    const tempPath = intermediateToUse || `/core/${this.apiVersion}`;
+    const url = urlUtil.format({
+      hostname: this.host,
+      pathname: `${tempPath}${pathname}`,
+      port: this.port,
+      protocol: this.protocol,
+      query
+    });
+
+    return decodeURIComponent(url);
+  }
+}

--- a/src/request/iHttpClient.ts
+++ b/src/request/iHttpClient.ts
@@ -2,5 +2,5 @@ import { IRequestConfig } from './iRequestConfig';
 
 // The HTTP Client must behave the following way:
 // * Throw an exception if the response code is not between 200 and 300
-// * Return an JavaScript object (i.e. not a response string)
+// * Return a JavaScript object of the server's JSON response
 export type IHttpClient = (arg1: IRequestConfig) => Promise<any>;

--- a/src/request/iHttpClient.ts
+++ b/src/request/iHttpClient.ts
@@ -1,0 +1,6 @@
+import { IRequestConfig } from './iRequestConfig';
+
+// The HTTP Client must behave the following way:
+// * Throw an exception if the response code is not between 200 and 300
+// * Return an JavaScript object (i.e. not a response string)
+export type IHttpClient = (arg1: IRequestConfig) => Promise<any>;

--- a/src/request/iRequestConfig.ts
+++ b/src/request/iRequestConfig.ts
@@ -1,0 +1,27 @@
+export type Method =
+  | 'get'
+  | 'GET'
+  | 'delete'
+  | 'DELETE'
+  | 'head'
+  | 'HEAD'
+  | 'options'
+  | 'OPTIONS'
+  | 'post'
+  | 'POST'
+  | 'put'
+  | 'PUT'
+  | 'patch'
+  | 'PATCH';
+
+export interface IRequestBaseConfig {
+  adapter?: (config: any) => Promise<any>;
+  timeout?: number;
+  headers?: any;
+}
+
+export interface IRequestConfig extends IRequestBaseConfig {
+  url: string;
+  method: Method;
+  body?: any;
+}

--- a/src/tempo.ts
+++ b/src/tempo.ts
@@ -1,4 +1,3 @@
-import { AxiosInstance } from 'axios';
 import AccountCategories from './collections/accountCategories';
 import AccountCategoryTypes from './collections/accountCategoryTypes';
 import AccountLinks from './collections/accountLinks';
@@ -16,6 +15,7 @@ import UserSchedule from './collections/userSchedule';
 import WorkAttributes from './collections/workAttributes';
 import Worklogs from './collections/worklogs';
 import * as QueryOptionTypes from './queryOptionTypes';
+import RequestBuilder from './request/builder';
 import RequestHandler from './request/handler';
 import * as RequestTypes from './requestTypes';
 import * as ResponseTypes from './responseTypes';
@@ -23,7 +23,6 @@ import * as ResponseTypes from './responseTypes';
 export interface ITempoApiOptions {
   requestHandler?: RequestHandler;
   port?: string;
-  request?: AxiosInstance;
   timeout?: number;
   protocol: string;
   host: string;
@@ -53,25 +52,28 @@ export default class TempoApi {
   public readonly userSchedule: UserSchedule;
   public readonly workAttributes: WorkAttributes;
   public readonly worklogs: Worklogs;
-  private readonly requestHandler: RequestHandler;
 
   constructor(options: ITempoApiOptions) {
-    this.requestHandler = options.requestHandler || new RequestHandler(options);
-    this.accountCategories = new AccountCategories(this.requestHandler);
-    this.accountCategoryTypes = new AccountCategoryTypes(this.requestHandler);
-    this.accountLinks = new AccountLinks(this.requestHandler);
-    this.accounts = new Accounts(this.requestHandler);
-    this.customers = new Customers(this.requestHandler);
-    this.periods = new Periods(this.requestHandler);
-    this.plans = new Plans(this.requestHandler);
-    this.programs = new Programs(this.requestHandler);
-    this.roles = new Roles(this.requestHandler);
-    this.teamMemberships = new TeamMemberships(this.requestHandler);
-    this.teamLinks = new TeamLinks(this.requestHandler);
-    this.teams = new Teams(this.requestHandler);
-    this.timesheetApprovals = new TimesheetApprovals(this.requestHandler);
-    this.userSchedule = new UserSchedule(this.requestHandler);
-    this.workAttributes = new WorkAttributes(this.requestHandler);
-    this.worklogs = new Worklogs(this.requestHandler);
+    const request = {
+      requestBuilder: new RequestBuilder(options),
+      requestHandler: options.requestHandler || new RequestHandler()
+    };
+
+    this.accountCategories = new AccountCategories(request);
+    this.accountCategoryTypes = new AccountCategoryTypes(request);
+    this.accountLinks = new AccountLinks(request);
+    this.accounts = new Accounts(request);
+    this.customers = new Customers(request);
+    this.periods = new Periods(request);
+    this.plans = new Plans(request);
+    this.programs = new Programs(request);
+    this.roles = new Roles(request);
+    this.teamMemberships = new TeamMemberships(request);
+    this.teamLinks = new TeamLinks(request);
+    this.teams = new Teams(request);
+    this.timesheetApprovals = new TimesheetApprovals(request);
+    this.userSchedule = new UserSchedule(request);
+    this.workAttributes = new WorkAttributes(request);
+    this.worklogs = new Worklogs(request);
   }
 }

--- a/src/tempo.ts
+++ b/src/tempo.ts
@@ -1,4 +1,4 @@
-import * as request from 'request-promise';
+import { AxiosInstance } from 'axios';
 import AccountCategories from './collections/accountCategories';
 import AccountCategoryTypes from './collections/accountCategoryTypes';
 import AccountLinks from './collections/accountLinks';
@@ -23,14 +23,13 @@ import * as ResponseTypes from './responseTypes';
 export interface ITempoApiOptions {
   requestHandler?: RequestHandler;
   port?: string;
-  request?: request.RequestPromiseAPI;
+  request?: AxiosInstance;
   timeout?: number;
   protocol: string;
   host: string;
   apiVersion: string;
   intermediatePath?: string;
   bearerToken?: string;
-  strictSSL?: boolean;
 }
 
 export { RequestTypes };

--- a/tests/collections/accountCategories.test.ts
+++ b/tests/collections/accountCategories.test.ts
@@ -8,10 +8,10 @@ describe('AccountCategories', () => {
     it('post hits proper url', async () => {
       const body = {};
       const result = await mockUrlCall.call('post', [body]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/account-categories'
       );
-      expect(result.body).toEqual(body);
+      expect(result.data).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
@@ -21,14 +21,14 @@ describe('AccountCategories', () => {
           id: 123
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/account-categories?id=123'
       );
     });
 
     it('getAccountCategory hits proper url', async () => {
       const result = await mockUrlCall.call('getAccountCategory', ['someKey']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/account-categories/someKey'
       );
     });
@@ -39,10 +39,10 @@ describe('AccountCategories', () => {
         'someKey',
         body
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/account-categories/someKey'
       );
-      expect(result.body).toEqual(body);
+      expect(result.data).toEqual(body);
       expect(result.method).toEqual('PUT');
     });
 
@@ -50,7 +50,7 @@ describe('AccountCategories', () => {
       const result = await mockUrlCall.call('deleteAccountCategory', [
         'someKey'
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/account-categories/someKey'
       );
       expect(result.method).toEqual('DELETE');

--- a/tests/collections/accountCategories.test.ts
+++ b/tests/collections/accountCategories.test.ts
@@ -11,7 +11,7 @@ describe('AccountCategories', () => {
       expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/account-categories'
       );
-      expect(result.data).toEqual(body);
+      expect(result.body).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
@@ -42,7 +42,7 @@ describe('AccountCategories', () => {
       expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/account-categories/someKey'
       );
-      expect(result.data).toEqual(body);
+      expect(result.body).toEqual(body);
       expect(result.method).toEqual('PUT');
     });
 

--- a/tests/collections/accountCategoryTypes.test.ts
+++ b/tests/collections/accountCategoryTypes.test.ts
@@ -7,7 +7,7 @@ describe('AccountCategoryTypes', () => {
   describe('Request Functions Tests', () => {
     it('get hits proper url', async () => {
       const result = await mockUrlCall.call('get', []);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/account-category-types'
       );
     });

--- a/tests/collections/accountLinks.test.ts
+++ b/tests/collections/accountLinks.test.ts
@@ -8,23 +8,23 @@ describe('AccountLinks', () => {
     it('post hits proper url', async () => {
       const body = {};
       const result = await mockUrlCall.call('post', [body]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/account-links'
       );
-      expect(result.body).toEqual(body);
+      expect(result.data).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
     it('getAccountLink hits proper url', async () => {
       const result = await mockUrlCall.call('getAccountLink', ['someId']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/account-links/someId'
       );
     });
 
     it('deleteAccountLink hits proper url', async () => {
       const result = await mockUrlCall.call('deleteAccountLink', ['someId']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/account-links/someId'
       );
       expect(result.method).toEqual('DELETE');
@@ -34,7 +34,7 @@ describe('AccountLinks', () => {
       const result = await mockUrlCall.call('getForProject', [
         'someProjectKey'
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/account-links/project/someProjectKey'
       );
     });

--- a/tests/collections/accountLinks.test.ts
+++ b/tests/collections/accountLinks.test.ts
@@ -11,7 +11,7 @@ describe('AccountLinks', () => {
       expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/account-links'
       );
-      expect(result.data).toEqual(body);
+      expect(result.body).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 

--- a/tests/collections/accounts.test.ts
+++ b/tests/collections/accounts.test.ts
@@ -11,7 +11,7 @@ describe('Accounts', () => {
       expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/accounts'
       );
-      expect(result.data).toEqual(body);
+      expect(result.body).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
@@ -39,7 +39,7 @@ describe('Accounts', () => {
       expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/accounts/someKey'
       );
-      expect(result.data).toEqual(body);
+      expect(result.body).toEqual(body);
       expect(result.method).toEqual('PUT');
     });
 

--- a/tests/collections/accounts.test.ts
+++ b/tests/collections/accounts.test.ts
@@ -8,10 +8,10 @@ describe('Accounts', () => {
     it('post hits proper url', async () => {
       const body = {};
       const result = await mockUrlCall.call('post', [body]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/accounts'
       );
-      expect(result.body).toEqual(body);
+      expect(result.data).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
@@ -21,14 +21,14 @@ describe('Accounts', () => {
           status: 'OPEN'
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/accounts?status=OPEN'
       );
     });
 
     it('getAccount hits proper url', async () => {
       const result = await mockUrlCall.call('getAccount', ['someKey']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/accounts/someKey'
       );
     });
@@ -36,16 +36,16 @@ describe('Accounts', () => {
     it('putAccount hits proper url', async () => {
       const body = {};
       const result = await mockUrlCall.call('putAccount', ['someKey', body]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/accounts/someKey'
       );
-      expect(result.body).toEqual(body);
+      expect(result.data).toEqual(body);
       expect(result.method).toEqual('PUT');
     });
 
     it('deleteAccount hits proper url', async () => {
       const result = await mockUrlCall.call('deleteAccount', ['someKey']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/accounts/someKey'
       );
       expect(result.method).toEqual('DELETE');
@@ -55,7 +55,7 @@ describe('Accounts', () => {
       const result = await mockUrlCall.call('getAccountLinksForAccount', [
         'someKey'
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/accounts/someKey/links'
       );
     });

--- a/tests/collections/customers.test.ts
+++ b/tests/collections/customers.test.ts
@@ -11,7 +11,7 @@ describe('Customers', () => {
       expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/customers'
       );
-      expect(result.data).toEqual(body);
+      expect(result.body).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
@@ -39,7 +39,7 @@ describe('Customers', () => {
       expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/customers/someKey'
       );
-      expect(result.data).toEqual(body);
+      expect(result.body).toEqual(body);
       expect(result.method).toEqual('PUT');
     });
 

--- a/tests/collections/customers.test.ts
+++ b/tests/collections/customers.test.ts
@@ -8,10 +8,10 @@ describe('Customers', () => {
     it('post hits proper url', async () => {
       const body = {};
       const result = await mockUrlCall.call('post', [body]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/customers'
       );
-      expect(result.body).toEqual(body);
+      expect(result.data).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
@@ -21,14 +21,14 @@ describe('Customers', () => {
           id: 456
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/customers?id=456'
       );
     });
 
     it('getCustomer hits proper url', async () => {
       const result = await mockUrlCall.call('getCustomer', ['someKey']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/customers/someKey'
       );
     });
@@ -36,16 +36,16 @@ describe('Customers', () => {
     it('putCustomer hits proper url', async () => {
       const body = {};
       const result = await mockUrlCall.call('putCustomer', ['someKey', body]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/customers/someKey'
       );
-      expect(result.body).toEqual(body);
+      expect(result.data).toEqual(body);
       expect(result.method).toEqual('PUT');
     });
 
     it('deleteCustomer hits proper url', async () => {
       const result = await mockUrlCall.call('deleteCustomer', ['someKey']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/customers/someKey'
       );
       expect(result.method).toEqual('DELETE');
@@ -55,7 +55,7 @@ describe('Customers', () => {
       const result = await mockUrlCall.call('getAccountsForCustomer', [
         'someKey'
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/customers/someKey/accounts'
       );
     });

--- a/tests/collections/mockHelpers.ts
+++ b/tests/collections/mockHelpers.ts
@@ -1,14 +1,12 @@
-export function getMockRequestHandlerOptions(options?: any) {
+export function getMockRequestBuilderOptions(options?: any) {
   const actualOptions = options || {};
   return {
     apiVersion: actualOptions.apiVersion || '3',
     bearerToken: actualOptions.bearer || 'sometoken',
-    ca: actualOptions.ca || null,
     host: actualOptions.host || 'tempo.somehost.com',
     intermediatePath: actualOptions.intermediatePath,
     port: actualOptions.port || '8080',
     protocol: actualOptions.protocol || 'http',
-    request: actualOptions.request,
     timeout: actualOptions.timeout || null
   };
 }

--- a/tests/collections/mockHelpers.ts
+++ b/tests/collections/mockHelpers.ts
@@ -9,9 +9,6 @@ export function getMockRequestHandlerOptions(options?: any) {
     port: actualOptions.port || '8080',
     protocol: actualOptions.protocol || 'http',
     request: actualOptions.request,
-    strictSSL: actualOptions.hasOwnProperty('strictSSL')
-      ? actualOptions.strictSSL
-      : true,
     timeout: actualOptions.timeout || null
   };
 }

--- a/tests/collections/mockUrlCall.ts
+++ b/tests/collections/mockUrlCall.ts
@@ -1,10 +1,19 @@
+import RequestBuilder from '../../src/request/builder';
 import RequestHandler from '../../src/request/handler';
-import { getMockRequestHandlerOptions } from './mockHelpers';
+import { getMockRequestBuilderOptions } from './mockHelpers';
+
+type CollectionTypeConstructor = new ({
+  requestBuilder,
+  requestHandler
+}: {
+  requestBuilder: RequestBuilder;
+  requestHandler: RequestHandler;
+}) => any;
 
 export default class MockUrlCall {
-  private collectionType: new (requestHandler: RequestHandler) => any;
+  private collectionType: CollectionTypeConstructor;
 
-  constructor(collectionType: new (requestHandler: RequestHandler) => any) {
+  constructor(collectionType: CollectionTypeConstructor) {
     this.collectionType = collectionType;
   }
 
@@ -12,15 +21,15 @@ export default class MockUrlCall {
     let externalRequestOptions: any = null;
     let dummyRequest = async (requestOptions: any) => {
       externalRequestOptions = requestOptions;
-      return { data: requestOptions };
+      return requestOptions;
     };
-    const requestHandler = new RequestHandler(
-      getMockRequestHandlerOptions({
-        request: dummyRequest
-      })
-    );
+    const requestBuilder = new RequestBuilder(getMockRequestBuilderOptions());
+    const requestHandler = new RequestHandler({ httpClient: dummyRequest });
 
-    const collection = new this.collectionType(requestHandler);
+    const collection = new this.collectionType({
+      requestBuilder,
+      requestHandler
+    });
 
     // For GET/POST/PUT requests, this will return the "dummyRequest" request
     // options, which is overridden at the top of this file.

--- a/tests/collections/mockUrlCall.ts
+++ b/tests/collections/mockUrlCall.ts
@@ -12,7 +12,7 @@ export default class MockUrlCall {
     let externalRequestOptions: any = null;
     let dummyRequest = async (requestOptions: any) => {
       externalRequestOptions = requestOptions;
-      return requestOptions;
+      return { data: requestOptions };
     };
     const requestHandler = new RequestHandler(
       getMockRequestHandlerOptions({

--- a/tests/collections/periods.test.ts
+++ b/tests/collections/periods.test.ts
@@ -12,7 +12,7 @@ describe('Periods', () => {
           to: '2019-01-31'
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/periods?from=2019-01-01&to=2019-01-31'
       );
     });

--- a/tests/collections/plans.test.ts
+++ b/tests/collections/plans.test.ts
@@ -17,14 +17,14 @@ describe('Plans', () => {
           limit: 5
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/plans?assigneeType=abc&planItemType=efg&from=2019-01-01&to=2019-01-31&updatedFrom=2019-01-01&offset=5&limit=5'
       );
     });
 
     it('post hits proper url', async () => {
       const result = await mockUrlCall.call('post', []);
-      expect(result.uri).toEqual('http://tempo.somehost.com:8080/core/3/plans');
+      expect(result.url).toEqual('http://tempo.somehost.com:8080/core/3/plans');
       expect(result.method).toEqual('POST');
     });
 
@@ -36,14 +36,14 @@ describe('Plans', () => {
           to: '2019-01-31'
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/plans/someId?from=2019-01-01&to=2019-01-31'
       );
     });
 
     it('putPlan hits proper url', async () => {
       const result = await mockUrlCall.call('putPlan', ['someId']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/plans/someId'
       );
       expect(result.method).toEqual('PUT');
@@ -51,7 +51,7 @@ describe('Plans', () => {
 
     it('deletePlan hits proper url', async () => {
       const result = await mockUrlCall.call('deletePlan', ['someId']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/plans/someId'
       );
       expect(result.method).toEqual('DELETE');
@@ -66,7 +66,7 @@ describe('Plans', () => {
           updatedFrom: '2019-01-01'
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/plans/user/someAccountId?from=2019-01-01&to=2019-01-31&updatedFrom=2019-01-01'
       );
     });

--- a/tests/collections/programs.test.ts
+++ b/tests/collections/programs.test.ts
@@ -7,7 +7,7 @@ describe('Programs', () => {
   describe('Request Functions Tests', () => {
     it('get hits proper url', async () => {
       const result = await mockUrlCall.call('get', []);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/programs'
       );
     });
@@ -15,16 +15,16 @@ describe('Programs', () => {
     it('post hits proper url', async () => {
       const body = {};
       const result = await mockUrlCall.call('post', [body]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/programs'
       );
-      expect(result.body).toEqual(body);
+      expect(result.data).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
     it('getProgram hits proper url', async () => {
       const result = await mockUrlCall.call('getProgram', ['someId']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/programs/someId'
       );
     });
@@ -32,16 +32,16 @@ describe('Programs', () => {
     it('putProgram hits proper url', async () => {
       const body = {};
       const result = await mockUrlCall.call('putProgram', ['someId', body]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/programs/someId'
       );
-      expect(result.body).toEqual(body);
+      expect(result.data).toEqual(body);
       expect(result.method).toEqual('PUT');
     });
 
     it('deleteProgram hits proper url', async () => {
       const result = await mockUrlCall.call('deleteProgram', ['someId']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/programs/someId'
       );
       expect(result.method).toEqual('DELETE');
@@ -49,7 +49,7 @@ describe('Programs', () => {
 
     it('getTeamsForProgram hits proper url', async () => {
       const result = await mockUrlCall.call('getTeamsForProgram', ['someId']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/programs/someId/teams'
       );
     });

--- a/tests/collections/programs.test.ts
+++ b/tests/collections/programs.test.ts
@@ -18,7 +18,7 @@ describe('Programs', () => {
       expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/programs'
       );
-      expect(result.data).toEqual(body);
+      expect(result.body).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
@@ -35,7 +35,7 @@ describe('Programs', () => {
       expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/programs/someId'
       );
-      expect(result.data).toEqual(body);
+      expect(result.body).toEqual(body);
       expect(result.method).toEqual('PUT');
     });
 

--- a/tests/collections/roles.test.ts
+++ b/tests/collections/roles.test.ts
@@ -7,20 +7,20 @@ describe('Roles', () => {
   describe('Request Functions Tests', () => {
     it('get hits proper url', async () => {
       const result = await mockUrlCall.call('get', []);
-      expect(result.uri).toEqual('http://tempo.somehost.com:8080/core/3/roles');
+      expect(result.url).toEqual('http://tempo.somehost.com:8080/core/3/roles');
     });
 
     it('post hits proper url', async () => {
       const body = {};
       const result = await mockUrlCall.call('post', [body]);
-      expect(result.uri).toEqual('http://tempo.somehost.com:8080/core/3/roles');
-      expect(result.body).toEqual(body);
+      expect(result.url).toEqual('http://tempo.somehost.com:8080/core/3/roles');
+      expect(result.data).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
     it('getRole hits proper url', async () => {
       const result = await mockUrlCall.call('getRole', ['someId']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/roles/someId'
       );
     });
@@ -28,16 +28,16 @@ describe('Roles', () => {
     it('putRole hits proper url', async () => {
       const body = {};
       const result = await mockUrlCall.call('putRole', ['someId', body]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/roles/someId'
       );
-      expect(result.body).toEqual(body);
+      expect(result.data).toEqual(body);
       expect(result.method).toEqual('PUT');
     });
 
     it('deleteRole hits proper url', async () => {
       const result = await mockUrlCall.call('deleteRole', ['someId']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/roles/someId'
       );
       expect(result.method).toEqual('DELETE');

--- a/tests/collections/roles.test.ts
+++ b/tests/collections/roles.test.ts
@@ -14,7 +14,7 @@ describe('Roles', () => {
       const body = {};
       const result = await mockUrlCall.call('post', [body]);
       expect(result.url).toEqual('http://tempo.somehost.com:8080/core/3/roles');
-      expect(result.data).toEqual(body);
+      expect(result.body).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
@@ -31,7 +31,7 @@ describe('Roles', () => {
       expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/roles/someId'
       );
-      expect(result.data).toEqual(body);
+      expect(result.body).toEqual(body);
       expect(result.method).toEqual('PUT');
     });
 

--- a/tests/collections/teamLinks.test.ts
+++ b/tests/collections/teamLinks.test.ts
@@ -11,7 +11,7 @@ describe('TeamLinks', () => {
       expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/team-links'
       );
-      expect(result.data).toEqual(body);
+      expect(result.body).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 

--- a/tests/collections/teamLinks.test.ts
+++ b/tests/collections/teamLinks.test.ts
@@ -8,23 +8,23 @@ describe('TeamLinks', () => {
     it('post hits proper url', async () => {
       const body = {};
       const result = await mockUrlCall.call('post', [body]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/team-links'
       );
-      expect(result.body).toEqual(body);
+      expect(result.data).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
     it('getTeamLink hits proper url', async () => {
       const result = await mockUrlCall.call('getTeamLink', ['someId']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/team-links/someId'
       );
     });
 
     it('deleteTeamLink hits proper url', async () => {
       const result = await mockUrlCall.call('deleteTeamLink', ['someId']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/team-links/someId'
       );
       expect(result.method).toEqual('DELETE');
@@ -34,7 +34,7 @@ describe('TeamLinks', () => {
       const result = await mockUrlCall.call('getForProject', [
         'someProjectKey'
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/team-links/project/someProjectKey'
       );
     });

--- a/tests/collections/teamMemberships.test.ts
+++ b/tests/collections/teamMemberships.test.ts
@@ -11,7 +11,7 @@ describe('TeamMemberships', () => {
       expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/team-memberships'
       );
-      expect(result.data).toEqual(body);
+      expect(result.body).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
@@ -31,7 +31,7 @@ describe('TeamMemberships', () => {
       expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/team-memberships/someId'
       );
-      expect(result.data).toEqual(body);
+      expect(result.body).toEqual(body);
       expect(result.method).toEqual('PUT');
     });
 

--- a/tests/collections/teamMemberships.test.ts
+++ b/tests/collections/teamMemberships.test.ts
@@ -8,16 +8,16 @@ describe('TeamMemberships', () => {
     it('post hits proper url', async () => {
       const body = {};
       const result = await mockUrlCall.call('post', [body]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/team-memberships'
       );
-      expect(result.body).toEqual(body);
+      expect(result.data).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
     it('getTeamMembership hits proper url', async () => {
       const result = await mockUrlCall.call('getTeamMembership', ['someId']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/team-memberships/someId'
       );
     });
@@ -28,16 +28,16 @@ describe('TeamMemberships', () => {
         'someId',
         body
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/team-memberships/someId'
       );
-      expect(result.body).toEqual(body);
+      expect(result.data).toEqual(body);
       expect(result.method).toEqual('PUT');
     });
 
     it('deleteTeamMembership hits proper url', async () => {
       const result = await mockUrlCall.call('deleteTeamMembership', ['someId']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/team-memberships/someId'
       );
       expect(result.method).toEqual('DELETE');

--- a/tests/collections/teams.test.ts
+++ b/tests/collections/teams.test.ts
@@ -8,19 +8,19 @@ describe('Teams', () => {
     it('post hits proper url', async () => {
       const body = {};
       const result = await mockUrlCall.call('post', [body]);
-      expect(result.uri).toEqual('http://tempo.somehost.com:8080/core/3/teams');
-      expect(result.body).toEqual(body);
+      expect(result.url).toEqual('http://tempo.somehost.com:8080/core/3/teams');
+      expect(result.data).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
     it('get hits proper url', async () => {
       const result = await mockUrlCall.call('get', []);
-      expect(result.uri).toEqual('http://tempo.somehost.com:8080/core/3/teams');
+      expect(result.url).toEqual('http://tempo.somehost.com:8080/core/3/teams');
     });
 
     it('getTeam hits proper url', async () => {
       const result = await mockUrlCall.call('getTeam', ['someId']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/teams/someId'
       );
     });
@@ -28,16 +28,16 @@ describe('Teams', () => {
     it('putTeam hits proper url', async () => {
       const body = {};
       const result = await mockUrlCall.call('putTeam', ['someId', body]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/teams/someId'
       );
-      expect(result.body).toEqual(body);
+      expect(result.data).toEqual(body);
       expect(result.method).toEqual('PUT');
     });
 
     it('deleteTeam hits proper url', async () => {
       const result = await mockUrlCall.call('deleteTeam', ['someId']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/teams/someId'
       );
       expect(result.method).toEqual('DELETE');
@@ -45,14 +45,14 @@ describe('Teams', () => {
 
     it('getTeamLinksForTeam hits proper url', async () => {
       const result = await mockUrlCall.call('getTeamLinksForTeam', ['someId']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/teams/someId/links'
       );
     });
 
     it('getMembersForTeam hits proper url', async () => {
       const result = await mockUrlCall.call('getMembersForTeam', ['someId']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/teams/someId/members'
       );
     });
@@ -62,7 +62,7 @@ describe('Teams', () => {
         'someId',
         'someAccountId'
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/teams/someId/members/someAccountId'
       );
     });
@@ -72,7 +72,7 @@ describe('Teams', () => {
         'someId',
         'someAccountId'
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/teams/someId/members/someAccountId/memberships'
       );
     });
@@ -81,7 +81,7 @@ describe('Teams', () => {
       const result = await mockUrlCall.call('getPermissionsForTeam', [
         'someId'
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/teams/someId/permissions'
       );
     });
@@ -91,7 +91,7 @@ describe('Teams', () => {
         'someId',
         'someKey'
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/teams/someId/permissions/someKey'
       );
     });

--- a/tests/collections/teams.test.ts
+++ b/tests/collections/teams.test.ts
@@ -9,7 +9,7 @@ describe('Teams', () => {
       const body = {};
       const result = await mockUrlCall.call('post', [body]);
       expect(result.url).toEqual('http://tempo.somehost.com:8080/core/3/teams');
-      expect(result.data).toEqual(body);
+      expect(result.body).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
@@ -31,7 +31,7 @@ describe('Teams', () => {
       expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/teams/someId'
       );
-      expect(result.data).toEqual(body);
+      expect(result.body).toEqual(body);
       expect(result.method).toEqual('PUT');
     });
 

--- a/tests/collections/timesheetApprovals.test.ts
+++ b/tests/collections/timesheetApprovals.test.ts
@@ -47,7 +47,7 @@ describe('TimesheetApprovals', () => {
       expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/timesheet-approvals/user/someAccountId/approve?from=2019-01-01&to=2019-01-31'
       );
-      expect(result.data).toEqual(body);
+      expect(result.body).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
@@ -64,7 +64,7 @@ describe('TimesheetApprovals', () => {
       expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/timesheet-approvals/user/someAccountId/reject?from=2019-01-01&to=2019-01-31'
       );
-      expect(result.data).toEqual(body);
+      expect(result.body).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
@@ -81,7 +81,7 @@ describe('TimesheetApprovals', () => {
       expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/timesheet-approvals/user/someAccountId/reopen?from=2019-01-01&to=2019-01-31'
       );
-      expect(result.data).toEqual(body);
+      expect(result.body).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
@@ -98,7 +98,7 @@ describe('TimesheetApprovals', () => {
       expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/timesheet-approvals/user/someAccountId/submit?from=2019-01-01&to=2019-01-31'
       );
-      expect(result.data).toEqual(body);
+      expect(result.body).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 

--- a/tests/collections/timesheetApprovals.test.ts
+++ b/tests/collections/timesheetApprovals.test.ts
@@ -7,7 +7,7 @@ describe('TimesheetApprovals', () => {
   describe('Request Functions Tests', () => {
     it('getWaiting hits proper url', async () => {
       const result = await mockUrlCall.call('getWaiting', []);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/timesheet-approvals/waiting'
       );
     });
@@ -20,7 +20,7 @@ describe('TimesheetApprovals', () => {
           to: '2019-01-31'
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/timesheet-approvals/user/someAccountId?from=2019-01-01&to=2019-01-31'
       );
     });
@@ -29,7 +29,7 @@ describe('TimesheetApprovals', () => {
       const result = await mockUrlCall.call('getReviewersForUser', [
         'someAccountId'
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/timesheet-approvals/user/someAccountId/reviewers'
       );
     });
@@ -44,10 +44,10 @@ describe('TimesheetApprovals', () => {
           to: '2019-01-31'
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/timesheet-approvals/user/someAccountId/approve?from=2019-01-01&to=2019-01-31'
       );
-      expect(result.body).toEqual(body);
+      expect(result.data).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
@@ -61,10 +61,10 @@ describe('TimesheetApprovals', () => {
           to: '2019-01-31'
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/timesheet-approvals/user/someAccountId/reject?from=2019-01-01&to=2019-01-31'
       );
-      expect(result.body).toEqual(body);
+      expect(result.data).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
@@ -78,10 +78,10 @@ describe('TimesheetApprovals', () => {
           to: '2019-01-31'
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/timesheet-approvals/user/someAccountId/reopen?from=2019-01-01&to=2019-01-31'
       );
-      expect(result.body).toEqual(body);
+      expect(result.data).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
@@ -95,10 +95,10 @@ describe('TimesheetApprovals', () => {
           to: '2019-01-31'
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/timesheet-approvals/user/someAccountId/submit?from=2019-01-01&to=2019-01-31'
       );
-      expect(result.body).toEqual(body);
+      expect(result.data).toEqual(body);
       expect(result.method).toEqual('POST');
     });
 
@@ -110,7 +110,7 @@ describe('TimesheetApprovals', () => {
           to: '2019-01-31'
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/timesheet-approvals/team/someTeamId?from=2019-01-01&to=2019-01-31'
       );
     });

--- a/tests/collections/userSchedule.test.ts
+++ b/tests/collections/userSchedule.test.ts
@@ -12,7 +12,7 @@ describe('UserSchedule', () => {
           to: '2019-01-31'
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/user-schedule?from=2019-01-01&to=2019-01-31'
       );
     });
@@ -25,7 +25,7 @@ describe('UserSchedule', () => {
           to: '2019-01-31'
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/user-schedule/someAccountId?from=2019-01-01&to=2019-01-31'
       );
     });

--- a/tests/collections/workAttributes.test.ts
+++ b/tests/collections/workAttributes.test.ts
@@ -7,14 +7,14 @@ describe('WorkAttributes', () => {
   describe('Request Functions Tests', () => {
     it('get hits proper url', async () => {
       const result = await mockUrlCall.call('get', []);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/work-attributes'
       );
     });
 
     it('getWorkAttribute hits proper url', async () => {
       const result = await mockUrlCall.call('getWorkAttribute', ['someKey']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/work-attributes/someKey'
       );
     });

--- a/tests/collections/worklogs.test.ts
+++ b/tests/collections/worklogs.test.ts
@@ -1,7 +1,5 @@
-import RequestHandler from '../../src/request/handler';
 import Worklogs from '../../src/collections/worklogs';
 import MockUrlCall from './mockUrlCall';
-import { getMockRequestHandlerOptions } from './mockHelpers';
 
 const mockUrlCall = new MockUrlCall(Worklogs);
 
@@ -9,7 +7,7 @@ describe('Worklogs', () => {
   describe('Request Functions Tests', () => {
     it('get hits proper url', async () => {
       const result = await mockUrlCall.call('get', []);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/worklogs'
       );
     });
@@ -26,7 +24,7 @@ describe('Worklogs', () => {
           limit: 5
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/worklogs?issue=someIssueA&issue=someIssueB&project=someProjectA&project=someProjectB&from=2019-01-01&to=2019-01-31&updatedFrom=2019-01-01&offset=5&limit=5'
       );
     });
@@ -36,16 +34,16 @@ describe('Worklogs', () => {
         timeSpentSeconds: 1234
       };
       const result = await mockUrlCall.call('post', [worklog]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/worklogs'
       );
       expect(result.method).toEqual('POST');
-      expect(result.body).toEqual(worklog);
+      expect(result.data).toEqual(worklog);
     });
 
     it('getWorklog hits proper url', async () => {
       const result = await mockUrlCall.call('getWorklog', ['someWorklogId']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/worklogs/someWorklogId'
       );
     });
@@ -58,16 +56,16 @@ describe('Worklogs', () => {
         'someWorklogId',
         worklog
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/worklogs/someWorklogId'
       );
       expect(result.method).toEqual('PUT');
-      expect(result.body).toEqual(worklog);
+      expect(result.data).toEqual(worklog);
     });
 
     it('deleteWorklog hits proper url and method', async () => {
       const result = await mockUrlCall.call('deleteWorklog', ['someWorklogId']);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/worklogs/someWorklogId'
       );
       expect(result.method).toEqual('DELETE');
@@ -77,7 +75,7 @@ describe('Worklogs', () => {
       const result = await mockUrlCall.call('getWorklogWorkAttributeValues', [
         'someWorklogId'
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/worklogs/someWorklogId/work-attribute-values'
       );
     });
@@ -87,7 +85,7 @@ describe('Worklogs', () => {
         'getWorklogWorkAttributeValuesByKey',
         ['someWorklogId', 'someKey']
       );
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/worklogs/someWorklogId/work-attribute-values/someKey'
       );
     });
@@ -96,7 +94,7 @@ describe('Worklogs', () => {
       const result = await mockUrlCall.call('getForJiraWorklog', [
         'someJiraWorklogId'
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/worklogs/jira/someJiraWorklogId'
       );
     });
@@ -112,7 +110,7 @@ describe('Worklogs', () => {
           limit: 5
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/worklogs/jira/filter/someJiraFilterId?from=2019-01-01&to=2019-01-31&updatedFrom=2019-01-01&offset=5&limit=5'
       );
     });
@@ -128,7 +126,7 @@ describe('Worklogs', () => {
           limit: 5
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/worklogs/account/someAccountKey?from=2019-01-01&to=2019-01-31&updatedFrom=2019-01-01&offset=5&limit=5'
       );
     });
@@ -144,7 +142,7 @@ describe('Worklogs', () => {
           limit: 5
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/worklogs/project/someProjectKey?from=2019-01-01&to=2019-01-31&updatedFrom=2019-01-01&offset=5&limit=5'
       );
     });
@@ -160,7 +158,7 @@ describe('Worklogs', () => {
           limit: 5
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/worklogs/team/someTeamId?from=2019-01-01&to=2019-01-31&updatedFrom=2019-01-01&offset=5&limit=5'
       );
     });
@@ -176,7 +174,7 @@ describe('Worklogs', () => {
           limit: 5
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/worklogs/user/someAccountId?from=2019-01-01&to=2019-01-31&updatedFrom=2019-01-01&offset=5&limit=5'
       );
     });
@@ -192,34 +190,9 @@ describe('Worklogs', () => {
           limit: 5
         }
       ]);
-      expect(result.uri).toEqual(
+      expect(result.url).toEqual(
         'http://tempo.somehost.com:8080/core/3/worklogs/issue/someKey?from=2019-01-01&to=2019-01-31&updatedFrom=2019-01-01&offset=5&limit=5'
       );
-    });
-  });
-
-  describe('Requests Error Tests', () => {
-    it('Mocked error messages throws errors', async () => {
-      expect.assertions(1);
-      const mockRequest = async (requestOptions: any) => {
-        return {
-          errors: [{ message: 'Something is clearly wrong!' }]
-        };
-      };
-
-      const requestHandler = new RequestHandler(
-        getMockRequestHandlerOptions({
-          request: mockRequest
-        })
-      );
-
-      const collection = new Worklogs(requestHandler);
-
-      try {
-        await collection.getForUser('someAccountId');
-      } catch (e) {
-        expect(e.message).toMatch('Something is clearly wrong!');
-      }
     });
   });
 });

--- a/tests/collections/worklogs.test.ts
+++ b/tests/collections/worklogs.test.ts
@@ -38,7 +38,7 @@ describe('Worklogs', () => {
         'http://tempo.somehost.com:8080/core/3/worklogs'
       );
       expect(result.method).toEqual('POST');
-      expect(result.data).toEqual(worklog);
+      expect(result.body).toEqual(worklog);
     });
 
     it('getWorklog hits proper url', async () => {
@@ -60,7 +60,7 @@ describe('Worklogs', () => {
         'http://tempo.somehost.com:8080/core/3/worklogs/someWorklogId'
       );
       expect(result.method).toEqual('PUT');
-      expect(result.data).toEqual(worklog);
+      expect(result.body).toEqual(worklog);
     });
 
     it('deleteWorklog hits proper url and method', async () => {

--- a/tests/request/axiosHttpClient.test.ts
+++ b/tests/request/axiosHttpClient.test.ts
@@ -3,14 +3,13 @@ import { IRequestConfig } from '../../src/request/iRequestConfig';
 
 describe('axiosHttpClient', () => {
   it('Maps requestConfig correctly', async () => {
-    // Use axios's method for mocking a network request:
-    // https://github.com/axios/axios/tree/master/lib/adapters
-    const adapter = async (config: any) => {
+    // Thankfully axios has a way to mock the network request
+    const adapter = async (axiosRequestConfig: any) => {
       return {
         data: {
           someOtherResponse: 'lorem ipsum',
           theOriginalRequestConfig: requestConfig,
-          theAxiosRequestConfig: config
+          theAxiosRequestConfig: axiosRequestConfig
         }
       };
     };

--- a/tests/request/axiosHttpClient.test.ts
+++ b/tests/request/axiosHttpClient.test.ts
@@ -1,0 +1,49 @@
+import axiosHttpClient from '../../src/request/axiosHttpClient';
+import { IRequestConfig } from '../../src/request/iRequestConfig';
+
+describe('axiosHttpClient', () => {
+  it('Maps requestConfig correctly', async () => {
+    // Use axios's method for mocking a network request:
+    // https://github.com/axios/axios/tree/master/lib/adapters
+    const adapter = async (config: any) => {
+      return {
+        data: {
+          someOtherResponse: 'lorem ipsum',
+          theOriginalRequestConfig: requestConfig,
+          theAxiosRequestConfig: config
+        }
+      };
+    };
+
+    const requestConfig: IRequestConfig = {
+      adapter,
+      url: 'http://www.example.com',
+      method: 'GET',
+      body: {
+        hello: 'world'
+      },
+      timeout: 1234,
+      headers: {
+        Authorization: 'Bearer myToken'
+      }
+    };
+
+    const result = await axiosHttpClient(requestConfig);
+
+    const expectedAxiosRequestConfig = {
+      url: 'http://www.example.com',
+      method: 'get',
+      data: '{"hello":"world"}',
+      timeout: 1234,
+      headers: {
+        Authorization: 'Bearer myToken'
+      }
+    };
+
+    expect(result.someOtherResponse).toEqual('lorem ipsum');
+    expect(result.theOriginalRequestConfig).toEqual(requestConfig);
+    expect(result.theAxiosRequestConfig).toMatchObject(
+      expectedAxiosRequestConfig
+    );
+  });
+});

--- a/tests/request/builder.test.ts
+++ b/tests/request/builder.test.ts
@@ -1,0 +1,99 @@
+import RequestBuilder from '../../src/request/builder';
+
+function getOptions(options?: any) {
+  const actualOptions = options || {};
+  return {
+    apiVersion: actualOptions.apiVersion || '3',
+    bearerToken: actualOptions.hasOwnProperty('bearerToken')
+      ? actualOptions.bearerToken
+      : 'someToken',
+    host: actualOptions.host || 'tempo.somehost.com',
+    intermediatePath: actualOptions.intermediatePath,
+    port: actualOptions.port || '8080',
+    protocol: actualOptions.protocol,
+    request: actualOptions.request,
+    timeout: actualOptions.timeout || null
+  };
+}
+
+describe('RequestBuilder', () => {
+  describe('Constructor Tests', () => {
+    it('Constructor functions properly', () => {
+      const builder = new RequestBuilder(
+        getOptions({
+          timeout: 3000
+        })
+      );
+
+      expect(builder.host).toEqual('tempo.somehost.com');
+      expect(builder.port).toEqual('8080');
+      expect(builder.baseOptions.headers).toEqual({
+        Authorization: `Bearer someToken`
+      });
+      expect(builder.baseOptions.timeout).toEqual(3000);
+      expect(builder.apiVersion).toEqual('3');
+
+      // Defaults are set to expected values
+      expect(builder.protocol).toEqual('https');
+
+      // Not having a bearerToken means no base auth headers are set
+      const handlerWithNoBearerToken = new RequestBuilder(
+        getOptions({ bearerToken: undefined, timeout: undefined })
+      );
+      expect(handlerWithNoBearerToken.baseOptions).toEqual({});
+      expect(handlerWithNoBearerToken.baseOptions.headers).toEqual(undefined);
+      expect(handlerWithNoBearerToken.baseOptions.timeout).toEqual(undefined);
+    });
+  });
+
+  describe('buildRequestConfig', () => {
+    it('Sets correct default values', () => {
+      const handler = new RequestBuilder(getOptions());
+
+      const requestHeader = handler.buildRequestConfig('https://example.com');
+      expect(requestHeader.method).toEqual('GET');
+      expect(requestHeader.url).toEqual('https://example.com');
+    });
+
+    it('Sets method based on options', () => {
+      const builder = new RequestBuilder(getOptions());
+      const requestHeader = builder.buildRequestConfig('https://example.com', {
+        method: 'DELETE'
+      });
+      expect(requestHeader.method).toEqual('DELETE');
+    });
+  });
+
+  describe('buildUrl', () => {
+    it('Sets correct default values', () => {
+      const builder = new RequestBuilder(getOptions());
+      const uri = builder.buildUrl({
+        pathname: '/collection/selector',
+        query: { queryKey: 'queryValue' }
+      });
+      expect(uri).toEqual(
+        'https://tempo.somehost.com:8080/core/3/collection/selector?queryKey=queryValue'
+      );
+    });
+
+    it('Sets intermediate path', () => {
+      const builder = new RequestBuilder(getOptions());
+      const uri = builder.buildUrl({
+        pathname: '/a/b',
+        intermediatePath: '/myCustomPath'
+      });
+      expect(uri).toEqual('https://tempo.somehost.com:8080/myCustomPath/a/b');
+    });
+
+    it('URI encodes parameters', () => {
+      const builder = new RequestBuilder(getOptions());
+      const uri = builder.buildUrl({
+        pathname: '/a/b',
+        query: { x: 'hello world' } // We do not want spaces to be encoded as %20
+      });
+      expect(uri).toEqual(
+        'https://tempo.somehost.com:8080/core/3/a/b?x=hello world'
+      );
+    });
+  });
+});

--- a/tests/request/handler.test.ts
+++ b/tests/request/handler.test.ts
@@ -1,100 +1,76 @@
 import requestHandler from '../../src/request/handler';
-
-function getOptions(options?: any) {
-  const actualOptions = options || {};
-  return {
-    apiVersion: actualOptions.apiVersion || '3',
-    bearerToken: actualOptions.hasOwnProperty('bearerToken')
-      ? actualOptions.bearerToken
-      : 'someToken',
-    host: actualOptions.host || 'tempo.somehost.com',
-    intermediatePath: actualOptions.intermediatePath,
-    port: actualOptions.port || '8080',
-    protocol: actualOptions.protocol,
-    request: actualOptions.request,
-    strictSSL: actualOptions.hasOwnProperty('strictSSL')
-      ? actualOptions.strictSSL
-      : undefined,
-    timeout: actualOptions.timeout || null
-  };
-}
+import { IRequestConfig } from '../../src/request/iRequestConfig';
 
 describe('requestHandler', () => {
   describe('Constructor Tests', () => {
-    it('Constructor functions properly', () => {
-      const handler = new requestHandler(
-        getOptions({
-          timeout: 3000
-        })
-      );
+    it('Constructor sets default httpClient', () => {
+      const handler = new requestHandler();
+      expect(handler.httpClient).toBeTruthy();
+    });
 
-      expect(handler.host).toEqual('tempo.somehost.com');
-      expect(handler.port).toEqual('8080');
-      expect(handler.baseOptions.headers).toEqual({
-        Authorization: `Bearer someToken`
+    it('Constructor sets httpClient from parameters', async () => {
+      const fakeHttpResponse = 'my fake HTTP Response';
+      const fakeHttpClient = async () => {
+        return fakeHttpResponse;
+      };
+
+      const handler = new requestHandler({ httpClient: fakeHttpClient });
+
+      expect(handler.httpClient).toBeTruthy();
+      const result = await handler.httpClient({
+        url: 'https://example.com',
+        method: 'GET'
       });
-      expect(handler.baseOptions.timeout).toEqual(3000);
-      expect(handler.apiVersion).toEqual('3');
-
-      // Defaults are set to expected values
-      expect(handler.protocol).toEqual('https');
-
-      // Not having a bearerToken means no base auth headers are set
-      const handlerWithNoBearerToken = new requestHandler(
-        getOptions({ bearerToken: undefined })
-      );
-      expect(handlerWithNoBearerToken.baseOptions).toEqual({});
-      expect(handlerWithNoBearerToken.baseOptions.auth).toEqual(undefined);
+      expect(result).toEqual(fakeHttpResponse);
     });
   });
 
   describe('doRequest', () => {
-    it('Merges some constructor options with requestHeader options', async () => {
-      const handler = new requestHandler(
-        getOptions({
-          timeout: 4000,
-          bearerToken: 'myFakeToken',
-          request: async (requestOptions: any) => {
-            return { data: requestOptions };
-          }
-        })
-      );
+    it('Passes requestConfig into httpClient', async () => {
+      const fakeHttpClient = async (requestConfig: IRequestConfig) => {
+        return requestConfig;
+      };
 
-      const mockResponse = await handler.doRequest({
-        url: 'https://example.com'
-      });
-      expect(mockResponse.url).toEqual('https://example.com');
-      expect(mockResponse.headers).toEqual({
-        Authorization: 'Bearer myFakeToken'
-      });
-      expect(mockResponse.timeout).toEqual(4000);
+      const handler = new requestHandler({ httpClient: fakeHttpClient });
+
+      const requestConfig: IRequestConfig = {
+        url: 'https://example.com',
+        method: 'POST',
+        body: {
+          hello: 'world'
+        },
+        timeout: 1234,
+        headers: {
+          Authoization: 'Bearer myBearerToken'
+        }
+      };
+      const result = await handler.doRequest(requestConfig);
+
+      expect(result).toEqual(requestConfig);
     });
 
     it('Returns falsey response if falsey', async () => {
-      const handler = new requestHandler(
-        getOptions({
-          request: async () => undefined
-        })
-      );
+      const fakeHttpClient = async () => {
+        return undefined;
+      };
+      const handler = new requestHandler({ httpClient: fakeHttpClient });
 
       const mockResponse = await handler.doRequest({
-        url: 'https://example.com'
+        url: 'https://example.com',
+        method: 'GET'
       });
       expect(mockResponse).toEqual(undefined);
     });
 
     it('Throws error if response throws error', async () => {
       expect.assertions(1);
-      const handler = new requestHandler(
-        getOptions({
-          request: async () => {
-            throw new Error('Request error');
-          }
-        })
-      );
+      const fakeHttpClient = async () => {
+        throw new Error('Request error');
+      };
+      const handler = new requestHandler({ httpClient: fakeHttpClient });
 
       try {
-        await handler.doRequest({ url: 'https://example.com' });
+        await handler.doRequest({ url: 'https://example.com', method: 'GET' });
       } catch (e) {
         expect(e.message).toMatch('Request error');
       }
@@ -102,20 +78,13 @@ describe('requestHandler', () => {
 
     it('Throws unknown error if error messages length is 0', async () => {
       expect.assertions(1);
-      const handler = new requestHandler(
-        getOptions({
-          request: async () => {
-            return {
-              data: {
-                errors: []
-              }
-            };
-          }
-        })
-      );
+      const fakeHttpClient = async () => {
+        return { errors: [] };
+      };
+      const handler = new requestHandler({ httpClient: fakeHttpClient });
 
       try {
-        await handler.doRequest({ url: 'https://example.com' });
+        await handler.doRequest({ url: 'https://example.com', method: 'GET' });
       } catch (e) {
         expect(e.message).toMatch('Unknown error');
       }
@@ -123,82 +92,18 @@ describe('requestHandler', () => {
 
     it('Throws error if error messages length is at least 1', async () => {
       expect.assertions(1);
-      const handler = new requestHandler(
-        getOptions({
-          request: async () => {
-            return {
-              data: {
-                errors: [{ message: 'Something went wrong!' }]
-              }
-            };
-          }
-        })
-      );
+      const fakeHttpClient = async () => {
+        return {
+          errors: [{ message: 'Something went wrong!' }]
+        };
+      };
+      const handler = new requestHandler({ httpClient: fakeHttpClient });
 
       try {
-        await handler.doRequest({ url: 'https://example.com' });
+        await handler.doRequest({ url: 'https://example.com', method: 'GET' });
       } catch (e) {
         expect(e.message).toMatch('Something went wrong!');
       }
-    });
-  });
-
-  describe('makeRequestHeader', () => {
-    it('Sets correct default values', () => {
-      const handler = new requestHandler(getOptions());
-
-      const requestHeader = handler.makeRequestHeader('https://example.com');
-      expect(requestHeader.method).toEqual('GET');
-      expect(requestHeader.url).toEqual('https://example.com');
-    });
-
-    it('Sets method based on options', () => {
-      const handler = new requestHandler(getOptions());
-      const requestHeader = handler.makeRequestHeader('https://example.com', {
-        method: 'DELETE'
-      });
-      expect(requestHeader.method).toEqual('DELETE');
-    });
-
-    it('Sets other request options', () => {
-      const handler = new requestHandler(getOptions());
-      const requestHeader = handler.makeRequestHeader('https://example.com', {
-        maxContentLength: 1024
-      });
-      expect(requestHeader.maxContentLength).toEqual(1024);
-    });
-  });
-
-  describe('makeUri', () => {
-    it('Sets correct default values', () => {
-      const handler = new requestHandler(getOptions());
-      const uri = handler.makeUri({
-        pathname: '/collection/selector',
-        query: { queryKey: 'queryValue' }
-      });
-      expect(uri).toEqual(
-        'https://tempo.somehost.com:8080/core/3/collection/selector?queryKey=queryValue'
-      );
-    });
-
-    it('Sets intermediate path', () => {
-      const handler = new requestHandler(getOptions());
-      const uri = handler.makeUri({
-        pathname: '/a/b',
-        intermediatePath: '/myCustomPath'
-      });
-      expect(uri).toEqual('https://tempo.somehost.com:8080/myCustomPath/a/b');
-    });
-
-    it('URI encodes parameters', () => {
-      const handler = new requestHandler(getOptions());
-      const uri = handler.makeUri({
-        pathname: '/a/b',
-        query: { x: 'hello world' } // We do not want spaces to be encoded as %20
-      });
-      expect(uri).toEqual(
-        'https://tempo.somehost.com:8080/core/3/a/b?x=hello world'
-      );
     });
   });
 });

--- a/tests/tempo.test.ts
+++ b/tests/tempo.test.ts
@@ -5,65 +5,67 @@ function getMockOptions(options?: any) {
   return {
     apiVersion: actualOptions.apiVersion || '3',
     bearerToken: actualOptions.bearer || 'sometoken',
-    ca: actualOptions.ca || null,
     host: actualOptions.host || 'tempo.somehost.com',
     intermediatePath: actualOptions.intermediatePath,
     port: actualOptions.port || '8080',
     protocol: actualOptions.protocol || 'http',
-    request: actualOptions.request,
-    strictSSL: actualOptions.hasOwnProperty('strictSSL')
-      ? actualOptions.strictSSL
-      : true,
+    requestHandler: actualOptions.requestHandler || undefined,
     timeout: actualOptions.timeout || null
   };
 }
 
 describe('TempoApi', () => {
+  describe('Constructor', () => {
+    const tempo = new TempoApi(getMockOptions());
+  });
+
   describe('Collections can be accessed', () => {
     it('Expect mocked data to be returned', async () => {
-      const dummyApiResponse = { data: { someSample: '...data to expect!' } };
+      const dummyApiResponse = { someSample: '...data to expect!' };
 
-      const dummyRequest = async () => dummyApiResponse;
+      const dummyRequestHandler = {
+        doRequest: async () => dummyApiResponse
+      };
       const tempo = new TempoApi(
         getMockOptions({
-          request: dummyRequest
+          requestHandler: dummyRequestHandler
         })
       );
 
       let result: any;
 
       result = await tempo.accountCategories.get();
-      expect(result).toBe(dummyApiResponse.data);
+      expect(result).toBe(dummyApiResponse);
       result = await tempo.accountCategoryTypes.get();
-      expect(result).toBe(dummyApiResponse.data);
+      expect(result).toBe(dummyApiResponse);
       result = await tempo.accountLinks.getAccountLink('123');
-      expect(result).toBe(dummyApiResponse.data);
+      expect(result).toBe(dummyApiResponse);
       result = await tempo.accounts.get();
-      expect(result).toBe(dummyApiResponse.data);
+      expect(result).toBe(dummyApiResponse);
       result = await tempo.customers.get();
-      expect(result).toBe(dummyApiResponse.data);
+      expect(result).toBe(dummyApiResponse);
       result = await tempo.periods.get();
-      expect(result).toBe(dummyApiResponse.data);
+      expect(result).toBe(dummyApiResponse);
       result = await tempo.plans.get();
-      expect(result).toBe(dummyApiResponse.data);
+      expect(result).toBe(dummyApiResponse);
       result = await tempo.programs.get();
-      expect(result).toBe(dummyApiResponse.data);
+      expect(result).toBe(dummyApiResponse);
       result = await tempo.roles.get();
-      expect(result).toBe(dummyApiResponse.data);
+      expect(result).toBe(dummyApiResponse);
       result = await tempo.teamLinks.getForProject('ABC');
-      expect(result).toBe(dummyApiResponse.data);
+      expect(result).toBe(dummyApiResponse);
       result = await tempo.teamMemberships.getTeamMembership('123');
-      expect(result).toBe(dummyApiResponse.data);
+      expect(result).toBe(dummyApiResponse);
       result = await tempo.teams.get();
-      expect(result).toBe(dummyApiResponse.data);
+      expect(result).toBe(dummyApiResponse);
       result = await tempo.timesheetApprovals.getWaiting();
-      expect(result).toBe(dummyApiResponse.data);
+      expect(result).toBe(dummyApiResponse);
       result = await tempo.userSchedule.get();
-      expect(result).toBe(dummyApiResponse.data);
+      expect(result).toBe(dummyApiResponse);
       result = await tempo.workAttributes.get();
-      expect(result).toBe(dummyApiResponse.data);
+      expect(result).toBe(dummyApiResponse);
       result = await tempo.worklogs.get();
-      expect(result).toBe(dummyApiResponse.data);
+      expect(result).toBe(dummyApiResponse);
     });
   });
 });

--- a/tests/tempo.test.ts
+++ b/tests/tempo.test.ts
@@ -21,7 +21,7 @@ function getMockOptions(options?: any) {
 describe('TempoApi', () => {
   describe('Collections can be accessed', () => {
     it('Expect mocked data to be returned', async () => {
-      const dummyApiResponse = { someSample: '...data to expect!' };
+      const dummyApiResponse = { data: { someSample: '...data to expect!' } };
 
       const dummyRequest = async () => dummyApiResponse;
       const tempo = new TempoApi(
@@ -33,37 +33,37 @@ describe('TempoApi', () => {
       let result: any;
 
       result = await tempo.accountCategories.get();
-      expect(result).toBe(dummyApiResponse);
+      expect(result).toBe(dummyApiResponse.data);
       result = await tempo.accountCategoryTypes.get();
-      expect(result).toBe(dummyApiResponse);
+      expect(result).toBe(dummyApiResponse.data);
       result = await tempo.accountLinks.getAccountLink('123');
-      expect(result).toBe(dummyApiResponse);
+      expect(result).toBe(dummyApiResponse.data);
       result = await tempo.accounts.get();
-      expect(result).toBe(dummyApiResponse);
+      expect(result).toBe(dummyApiResponse.data);
       result = await tempo.customers.get();
-      expect(result).toBe(dummyApiResponse);
+      expect(result).toBe(dummyApiResponse.data);
       result = await tempo.periods.get();
-      expect(result).toBe(dummyApiResponse);
+      expect(result).toBe(dummyApiResponse.data);
       result = await tempo.plans.get();
-      expect(result).toBe(dummyApiResponse);
+      expect(result).toBe(dummyApiResponse.data);
       result = await tempo.programs.get();
-      expect(result).toBe(dummyApiResponse);
+      expect(result).toBe(dummyApiResponse.data);
       result = await tempo.roles.get();
-      expect(result).toBe(dummyApiResponse);
+      expect(result).toBe(dummyApiResponse.data);
       result = await tempo.teamLinks.getForProject('ABC');
-      expect(result).toBe(dummyApiResponse);
+      expect(result).toBe(dummyApiResponse.data);
       result = await tempo.teamMemberships.getTeamMembership('123');
-      expect(result).toBe(dummyApiResponse);
+      expect(result).toBe(dummyApiResponse.data);
       result = await tempo.teams.get();
-      expect(result).toBe(dummyApiResponse);
+      expect(result).toBe(dummyApiResponse.data);
       result = await tempo.timesheetApprovals.getWaiting();
-      expect(result).toBe(dummyApiResponse);
+      expect(result).toBe(dummyApiResponse.data);
       result = await tempo.userSchedule.get();
-      expect(result).toBe(dummyApiResponse);
+      expect(result).toBe(dummyApiResponse.data);
       result = await tempo.workAttributes.get();
-      expect(result).toBe(dummyApiResponse);
+      expect(result).toBe(dummyApiResponse.data);
       result = await tempo.worklogs.get();
-      expect(result).toBe(dummyApiResponse);
+      expect(result).toBe(dummyApiResponse.data);
     });
   });
 });

--- a/tests/tempoDocumentation.test.ts
+++ b/tests/tempoDocumentation.test.ts
@@ -1,11 +1,16 @@
-import * as request from 'request-promise';
+import axios from 'axios';
 
 describe('Tempo REST API Documentation', () => {
-    // This test is used to identify whether the documentation on Tempo's
-    // website has updated. If the test fails, that means there must have been
-    // some change to their API, and therefore should be addressed.
-    it('has not changed', async () => {
-        const html = await request('https://tempo-io.github.io/tempo-api-docs/')
-        expect(html).toMatchSnapshot();
-    });
+  // This test is used to identify whether the documentation on Tempo's
+  // website has updated. If the test fails, that means there must have been
+  // some change to their API, and therefore should be addressed.
+  it('has not changed', async () => {
+    const response = await axios.get(
+      'https://tempo-io.github.io/tempo-api-docs/',
+      {
+        responseType: 'text'
+      }
+    );
+    expect(response.data).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
This PR switches the dependency from `request-promise` to `axios`.

### Why

`request-promise@4.2.5` takes 2.54 MB to install: ![Size of request-promise@4.2.5](https://badgen.net/packagephobia/install/request-promise@4.2.5)

... compared to `axios@0.19.0` which takes 0.41 MB to install: ![Size of axios@0.19.0](https://badgen.net/packagephobia/install/axios@0.19.0)

`tempo-client` has an install size of 2.63 MB, which means `request-promise` is 96% of the package!

### Breaking changes

Unfortunately, a lot of functionality was tightly coupled to `request-promise`. 

So a big portion of this PR is decoupling the network request handling and refactoring the tests to not be so tightly coupled to request-promise or axios!

Notable things that were deprecated:

- `strictSSL` (a.k.a `rejectUnauthorized`)
- All other `options` as part of request-promise: https://github.com/request/request#requestoptions-callback