### PR TITLE
NPM Update (typedoc, @types) + peaceiris/actions-gh-pages forceOrphan

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,8 +25,10 @@ jobs:
         sed -i '/doc/d' .gitignore
         echo "tempo-client.leifgehrmann.com" >> ./doc/CNAME
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@v2.5.0
+      uses: peaceiris/actions-gh-pages@v2.6.0
       env:
         ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         PUBLISH_BRANCH: gh-pages
         PUBLISH_DIR: ./doc
+      with:
+        forceOrphan: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [8.x, 10.x, 12.x, 13.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/package-lock.json
+++ b/package-lock.json
@@ -3517,9 +3517,9 @@
       }
     },
     "marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.0.tgz",
+      "integrity": "sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ==",
       "dev": true
     },
     "merge-stream": {
@@ -4927,9 +4927,9 @@
       }
     },
     "typedoc": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.15.5.tgz",
-      "integrity": "sha512-AKXLtOUCLRlSTyfXQHYp3LFPy6RiFLnxnKS5z1jwQsYXmCPbHWuhmfgS264Es2hPMZjzvHqk/ZQDzCBpb49u6w==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.15.6.tgz",
+      "integrity": "sha512-TC3j7HXFfyq0/NyUL9oLgEXhgO4U8Kd7iyRgagkG3XxehgTjn6w20uJ/Hif1KPB/65VQZ8uMYYyxFXNj9um5Ow==",
       "dev": true,
       "requires": {
         "@types/minimatch": "3.0.3",
@@ -4937,18 +4937,18 @@
         "handlebars": "^4.5.3",
         "highlight.js": "^9.17.1",
         "lodash": "^4.17.15",
-        "marked": "^0.7.0",
+        "marked": "^0.8.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
         "shelljs": "^0.8.3",
-        "typedoc-default-themes": "^0.6.2",
+        "typedoc-default-themes": "^0.6.3",
         "typescript": "3.7.x"
       }
     },
     "typedoc-default-themes": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.6.2.tgz",
-      "integrity": "sha512-+O+1aHjVIpDLsbkIDkZSNu+kutqmg7WdzahT+4KwBC/95mUgAb0xkbwdPpEJEpRX0ov1UJoCmvEPb1/VHxnTuw==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.6.3.tgz",
+      "integrity": "sha512-rouf0TcIA4M2nOQFfC7Zp4NEwoYiEX4vX/ZtudJWU9IHA29MPC+PPgSXYLPESkUo7FuB//GxigO3mk9Qe1xp3Q==",
       "dev": true,
       "requires": {
         "backbone": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -474,9 +474,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.22",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.22.tgz",
-      "integrity": "sha512-r5i93jqbPWGXYXxianGATOxTelkp6ih/U0WVnvaqAvTqM+0U6J3kw6Xk6uq/dWNRkEVw/0SLcO5ORXbVNz4FMQ==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.1.tgz",
+      "integrity": "sha512-hx6zWtudh3Arsbl3cXay+JnkvVgCKzCWKv42C9J01N2T2np4h8w5X8u6Tpz5mj38kE3M9FM0Pazx8vKFFMnjLQ==",
       "dev": true
     },
     "@types/stack-utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -459,9 +459,9 @@
       }
     },
     "@types/jest": {
-      "version": "24.0.24",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.24.tgz",
-      "integrity": "sha512-vgaG968EDPSJPMunEDdZvZgvxYSmeH8wKqBlHSkBt1pV2XlLEVDzsj1ZhLuI4iG4Pv841tES61txSBF0obh4CQ==",
+      "version": "24.0.25",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.25.tgz",
+      "integrity": "sha512-hnP1WpjN4KbGEK4dLayul6lgtys6FPz0UfxMeMQCv0M+sTnzN3ConfiO72jHgLxl119guHgI8gLqDOrRLsyp2g==",
       "dev": true,
       "requires": {
         "jest-diff": "^24.3.0"
@@ -474,9 +474,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.21.tgz",
-      "integrity": "sha512-8sRGhbpU+ck1n0PGAUgVrWrWdjSW2aqNeyC15W88GRsMpSwzv6RJGlLhE7s2RhVSOdyDmxbqlWSeThq4/7xqlA==",
+      "version": "12.12.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.22.tgz",
+      "integrity": "sha512-r5i93jqbPWGXYXxianGATOxTelkp6ih/U0WVnvaqAvTqM+0U6J3kw6Xk6uq/dWNRkEVw/0SLcO5ORXbVNz4FMQ==",
       "dev": true
     },
     "@types/stack-utils": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ts-jest": "^24.2.0",
     "tslint": "^5.20.1",
     "tslint-config-prettier": "^1.18.0",
-    "typedoc": "^0.15.5",
+    "typedoc": "^0.15.6",
     "typescript": "^3.7.4"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/leifgehrmann/node-tempo-client#readme",
   "devDependencies": {
     "@types/jest": "^24.0.25",
-    "@types/node": "^12.12.22",
+    "@types/node": "^13.1.1",
     "codecov": "^3.6.1",
     "jest": "^24.9.0",
     "prettier": "^1.19.1",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "homepage": "https://github.com/leifgehrmann/node-tempo-client#readme",
   "devDependencies": {
-    "@types/jest": "^24.0.24",
-    "@types/node": "^12.12.21",
+    "@types/jest": "^24.0.25",
+    "@types/node": "^12.12.22",
     "codecov": "^3.6.1",
     "jest": "^24.9.0",
     "prettier": "^1.19.1",


### PR DESCRIPTION
Updated dev dependencies, which includes updating typedoc.

Also implemented `forceOrphan` for the GitHub pages to minimise spam in git history in the `gh-pages` branch. For more info, see: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-force-orphan