### PR TITLE
Replace deprecated legacy "url" object with WHATWG URL API

### DIFF
--- a/src/collections/abstractCollection.ts
+++ b/src/collections/abstractCollection.ts
@@ -24,7 +24,7 @@ export default abstract class Collection {
       method,
       body
     }: {
-      query?: Partial<{ [key: string]: string }>;
+      query?: { [key: string]: string };
       method?: Method;
       body?: any;
     } = {}

--- a/src/request/builder.ts
+++ b/src/request/builder.ts
@@ -59,13 +59,13 @@ export default class Builder {
   public buildUrl({ pathname, query, intermediatePath }: IUrlOptions) {
     const intermediateToUse = this.intermediatePath || intermediatePath;
     const tempPath = intermediateToUse || `/core/${this.apiVersion}`;
-    const url = new URL('https://example.com')
-    url.host = this.host
-    url.pathname = `${tempPath}${pathname}`
+    const url = new URL('https://example.com');
+    url.host = this.host;
+    url.pathname = `${tempPath}${pathname}`;
     if (this.port !== undefined) {
-      url.port = this.port
+      url.port = this.port;
     }
-    url.protocol = this.protocol
+    url.protocol = this.protocol;
     url.search = queryStringify(query);
 
     return decodeURIComponent(url.href);

--- a/src/request/builder.ts
+++ b/src/request/builder.ts
@@ -1,4 +1,4 @@
-import * as urlUtil from 'url';
+import { stringify as queryStringify } from 'querystring';
 import { IRequestBaseConfig, IRequestConfig, Method } from './iRequestConfig';
 
 interface IRequestBuilderConfig {
@@ -13,7 +13,7 @@ interface IRequestBuilderConfig {
 
 interface IUrlOptions {
   pathname: string;
-  query?: Partial<{ [key: string]: string }>;
+  query?: { [key: string]: string };
   intermediatePath?: string;
 }
 
@@ -59,14 +59,15 @@ export default class Builder {
   public buildUrl({ pathname, query, intermediatePath }: IUrlOptions) {
     const intermediateToUse = this.intermediatePath || intermediatePath;
     const tempPath = intermediateToUse || `/core/${this.apiVersion}`;
-    const url = urlUtil.format({
-      hostname: this.host,
-      pathname: `${tempPath}${pathname}`,
-      port: this.port,
-      protocol: this.protocol,
-      query
-    });
+    const url = new URL('https://example.com')
+    url.host = this.host
+    url.pathname = `${tempPath}${pathname}`
+    if (this.port !== undefined) {
+      url.port = this.port
+    }
+    url.protocol = this.protocol
+    url.search = queryStringify(query);
 
-    return decodeURIComponent(url);
+    return decodeURIComponent(url.href);
   }
 }

--- a/tests/request/builder.test.ts
+++ b/tests/request/builder.test.ts
@@ -9,7 +9,7 @@ function getOptions(options?: any) {
       : 'someToken',
     host: actualOptions.host || 'tempo.somehost.com',
     intermediatePath: actualOptions.intermediatePath,
-    port: actualOptions.port || '8080',
+    port: actualOptions.port,
     protocol: actualOptions.protocol,
     request: actualOptions.request,
     timeout: actualOptions.timeout || null
@@ -26,7 +26,6 @@ describe('RequestBuilder', () => {
       );
 
       expect(builder.host).toEqual('tempo.somehost.com');
-      expect(builder.port).toEqual('8080');
       expect(builder.baseOptions.headers).toEqual({
         Authorization: `Bearer someToken`
       });
@@ -35,6 +34,9 @@ describe('RequestBuilder', () => {
 
       // Defaults are set to expected values
       expect(builder.protocol).toEqual('https');
+      
+      // Not having a port means port will be left undefined
+      expect(builder.port).toEqual(undefined);
 
       // Not having a bearerToken means no base auth headers are set
       const handlerWithNoBearerToken = new RequestBuilder(
@@ -44,11 +46,33 @@ describe('RequestBuilder', () => {
       expect(handlerWithNoBearerToken.baseOptions.headers).toEqual(undefined);
       expect(handlerWithNoBearerToken.baseOptions.timeout).toEqual(undefined);
     });
+
+    it('Port and protocol can be modified', () => {
+      const builder = new RequestBuilder(
+        getOptions({
+          protocol: 'http',
+          port: '80'
+        })
+      );
+
+      expect(builder.protocol).toEqual('http');
+      expect(builder.port).toEqual('80');
+    });
+
+    it('Port is nullable', () => {
+      const builder = new RequestBuilder(
+        getOptions({
+          port: null
+        })
+      );
+      
+      expect(builder.port).toEqual(null);
+    });
   });
 
   describe('buildRequestConfig', () => {
     it('Sets correct default values', () => {
-      const handler = new RequestBuilder(getOptions());
+      const handler = new RequestBuilder(getOptions({port: '8080'}));
 
       const requestHeader = handler.buildRequestConfig('https://example.com');
       expect(requestHeader.method).toEqual('GET');
@@ -56,7 +80,7 @@ describe('RequestBuilder', () => {
     });
 
     it('Sets method based on options', () => {
-      const builder = new RequestBuilder(getOptions());
+      const builder = new RequestBuilder(getOptions({port: '8080'}));
       const requestHeader = builder.buildRequestConfig('https://example.com', {
         method: 'DELETE'
       });
@@ -72,8 +96,24 @@ describe('RequestBuilder', () => {
         query: { queryKey: 'queryValue' }
       });
       expect(uri).toEqual(
-        'https://tempo.somehost.com:8080/core/3/collection/selector?queryKey=queryValue'
+        'https://tempo.somehost.com/core/3/collection/selector?queryKey=queryValue'
       );
+    });
+
+    it('Sets port correctly', () => {
+      const builder = new RequestBuilder(getOptions({port: '8080'}));
+      const uri = builder.buildUrl({
+        pathname: '/a/b'
+      });
+      expect(uri).toEqual('https://tempo.somehost.com:8080/core/3/a/b');
+    });
+
+    it('Sets port correctly if null', () => {
+      const builder = new RequestBuilder(getOptions({port: null}));
+      const uri = builder.buildUrl({
+        pathname: '/a/b'
+      });
+      expect(uri).toEqual('https://tempo.somehost.com/core/3/a/b');
     });
 
     it('Sets intermediate path', () => {
@@ -82,7 +122,7 @@ describe('RequestBuilder', () => {
         pathname: '/a/b',
         intermediatePath: '/myCustomPath'
       });
-      expect(uri).toEqual('https://tempo.somehost.com:8080/myCustomPath/a/b');
+      expect(uri).toEqual('https://tempo.somehost.com/myCustomPath/a/b');
     });
 
     it('URI encodes parameters', () => {
@@ -92,7 +132,7 @@ describe('RequestBuilder', () => {
         query: { x: 'hello world' } // We do not want spaces to be encoded as %20
       });
       expect(uri).toEqual(
-        'https://tempo.somehost.com:8080/core/3/a/b?x=hello world'
+        'https://tempo.somehost.com/core/3/a/b?x=hello world'
       );
     });
   });

--- a/tests/request/builder.test.ts
+++ b/tests/request/builder.test.ts
@@ -34,7 +34,7 @@ describe('RequestBuilder', () => {
 
       // Defaults are set to expected values
       expect(builder.protocol).toEqual('https');
-      
+
       // Not having a port means port will be left undefined
       expect(builder.port).toEqual(undefined);
 
@@ -65,14 +65,14 @@ describe('RequestBuilder', () => {
           port: null
         })
       );
-      
+
       expect(builder.port).toEqual(null);
     });
   });
 
   describe('buildRequestConfig', () => {
     it('Sets correct default values', () => {
-      const handler = new RequestBuilder(getOptions({port: '8080'}));
+      const handler = new RequestBuilder(getOptions());
 
       const requestHeader = handler.buildRequestConfig('https://example.com');
       expect(requestHeader.method).toEqual('GET');
@@ -80,7 +80,7 @@ describe('RequestBuilder', () => {
     });
 
     it('Sets method based on options', () => {
-      const builder = new RequestBuilder(getOptions({port: '8080'}));
+      const builder = new RequestBuilder(getOptions());
       const requestHeader = builder.buildRequestConfig('https://example.com', {
         method: 'DELETE'
       });
@@ -101,7 +101,7 @@ describe('RequestBuilder', () => {
     });
 
     it('Sets port correctly', () => {
-      const builder = new RequestBuilder(getOptions({port: '8080'}));
+      const builder = new RequestBuilder(getOptions({ port: '8080' }));
       const uri = builder.buildUrl({
         pathname: '/a/b'
       });
@@ -109,7 +109,7 @@ describe('RequestBuilder', () => {
     });
 
     it('Sets port correctly if null', () => {
-      const builder = new RequestBuilder(getOptions({port: null}));
+      const builder = new RequestBuilder(getOptions({ port: null }));
       const uri = builder.buildUrl({
         pathname: '/a/b'
       });


### PR DESCRIPTION
After attempting to upgrade the `@types/node` dev dependency from `v12.12.21` to `v12.12.22`, Typescript complains that `url.format` doesn't work any more. I'm not entirely sure why... `url.d.ts` hasn't changed. Example of the error is shown below:

```
> tsc

src/request/builder.ts:62:17 - error TS2769: No overload matches this call.
  Overload 1 of 2, '(URL: URL, options?: URLFormatOptions | undefined): string', gave the following error.
    Type 'string | undefined' is not assignable to type 'string'.
      Type 'undefined' is not assignable to type 'string'.
  Overload 2 of 2, '(urlObject: string | UrlObject): string', gave the following error.
    Argument of type '{ hostname: string; pathname: string; port: string | undefined; protocol: string; query: Partial<{ [key: string]: string; }> | undefined; }' is not assignable to parameter of type 'string | UrlObject'.
      Type '{ hostname: string; pathname: string; port: string | undefined; protocol: string; query: Partial<{ [key: string]: string; }> | undefined; }' is not assignable to type 'UrlObject'.
        Types of property 'query' are incompatible.
          Type 'Partial<{ [key: string]: string; }> | undefined' is not assignable to type 'string | ParsedUrlQueryInput | null | undefined'.
            Type 'Partial<{ [key: string]: string; }>' is not assignable to type 'string | ParsedUrlQueryInput | null | undefined'.
              Type 'Partial<{ [key: string]: string; }>' is not assignable to type 'string'.

 62     const url = urlUtil.format({
                    ~~~~~~~~~~~~~~~~
 63       hostname: this.host,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~
... 
 67       query
    ~~~~~~~~~~~
 68     });
    ~~~~~~

  node_modules/@types/node/url.d.ts:86:9
    86         port: string;
               ~~~~
    The expected type comes from property 'port' which is declared here on type 'URL'


Found 1 error.
```

I would have looked into it more, but apparently `url.format` is [deprecated anyway](https://nodejs.org/dist/latest-v8.x/docs/api/url.html#url_url_format_urlobject)

This MR replaces it with the [WHATWG URL API](https://nodejs.org/dist/latest-v8.x/docs/api/url.html#url_the_whatwg_url_api), introduced in Node 7.x. Thankfully we don't expect to support Node 7.x, as our pipeline supports at a minimum Node 8.x. (Node 7.x also EOL'd in 2017)

["query strings"](https://nodejs.org/dist/latest-v8.x/docs/api/querystring.html) also needed to handle the search queries, as the URL API does not provide out of the box support for them compared to url.format.

I also remove the `Partial<{ [key: string]: string }>`... I don't know what I was thinking when writing this.