### PR TITLE
Remove "npm audit" & "npm outdated" workflows on PRs

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -1,8 +1,9 @@
 name: NPM Audit
 
-on: 
+on:
   push:
-  pull_request:
+    branches:
+    - master
   schedule:
     - cron: '0 6 * * 1'
 

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -3,7 +3,7 @@ name: NPM Audit
 on:
   push:
     branches:
-    - master
+      - master
   schedule:
     - cron: '0 6 * * 1'
 

--- a/.github/workflows/npm-outdated.yml
+++ b/.github/workflows/npm-outdated.yml
@@ -1,8 +1,9 @@
 name: NPM Outdated
 
-on: 
+on:
   push:
-  pull_request:
+    branches:
+    - master
   schedule:
     - cron: '0 6 * * 1'
 

--- a/.github/workflows/npm-outdated.yml
+++ b/.github/workflows/npm-outdated.yml
@@ -3,7 +3,7 @@ name: NPM Outdated
 on:
   push:
     branches:
-    - master
+      - master
   schedule:
     - cron: '0 6 * * 1'
 


### PR DESCRIPTION
It is unnecessary for the workflows to run in a pull request, as the cron for the master branch will run weekly and send emails to the maintainers that the dependencies are outdated or require an audit.

This PR simply removes the PR triggers for the `npm-audit.yml` and `npm-outdated.yml`, and adds a trigger for pushing commits to the `master` branch.