### PR TITLE
Fix code coverage pipeline in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ node_js:
   - "node"
 scripts:
   - npm install codecov -g
+  - npm test
 after_success:
   - codecov


### PR DESCRIPTION
For some reason travis-ci no longer appears to run the tests, meaning codecov can't find the code coverage reports.