### PR TITLE
Tempo REST API feature changes

### DIFF
--- a/src/collections/holidaySchemes.ts
+++ b/src/collections/holidaySchemes.ts
@@ -1,0 +1,26 @@
+import * as queryOptions from '../queryOptionTypes';
+import {
+  HolidaySchemeResponse,
+  HolidayResponse,
+  ResultSetResponse,
+} from '../responseTypes';
+import Collection from './abstractCollection';
+
+export default class HolidaySchemes extends Collection {
+  public async get(): Promise<ResultSetResponse<HolidaySchemeResponse>> {
+    return this.createAndSendRequest('/holiday-schemes');
+  }
+
+  public async getHolidayScheme(id: string): Promise<HolidaySchemeResponse> {
+    return this.createAndSendRequest(`/holiday-schemes/${id}`);
+  }
+
+  public async getHolidaySchemeHolidays(
+    id: string,
+    options: queryOptions.Year,
+  ): Promise<HolidayResponse> {
+    return this.createAndSendRequest(`/holiday-schemes/${id}/holidays`, {
+      query: options,
+    });
+  }
+}

--- a/src/collections/workloadSchemes.ts
+++ b/src/collections/workloadSchemes.ts
@@ -1,0 +1,15 @@
+import {
+  WorkloadSchemeResponse,
+  ResultSetResponse,
+} from '../responseTypes';
+import Collection from './abstractCollection';
+
+export default class WorkloadSchemes extends Collection {
+  public async get(): Promise<ResultSetResponse<WorkloadSchemeResponse>> {
+    return this.createAndSendRequest('/workload-schemes');
+  }
+
+  public async getWorkloadScheme(id: string): Promise<WorkloadSchemeResponse> {
+    return this.createAndSendRequest(`/workload-schemes/${id}`);
+  }
+}

--- a/src/queryOptionTypes.ts
+++ b/src/queryOptionTypes.ts
@@ -37,3 +37,7 @@ export interface AssigneeType extends StringMap {
 export interface PlanItemType extends StringMap {
   planItemType: string;
 }
+
+export interface Year extends StringMap {
+  year: number;
+}

--- a/src/responseTypes.ts
+++ b/src/responseTypes.ts
@@ -81,6 +81,8 @@ export interface PlanResponse {
   id: number;
   startDate: string;
   endDate: string;
+  secondsPerDay: number;
+  includeNonWorkingDays: boolean;
   description?: string;
   createdAt: string;
   updatedAt: string;

--- a/src/responseTypes.ts
+++ b/src/responseTypes.ts
@@ -322,3 +322,34 @@ export interface ProgramResponse {
     values: TeamRefResponse[];
   };
 }
+
+export interface HolidaySchemeResponse {
+  self: string;
+  id: number;
+  name: string;
+  description?: string;
+  defaultScheme: boolean;
+  memberCount: number;
+}
+
+export interface HolidayResponse {
+  name: string;
+  description?: string;
+  durationSeconds: number;
+  date: string;
+}
+
+export interface WorkloadSchemeResponse {
+  self: string;
+  id: number;
+  name: string;
+  description?: string;
+  defaultScheme: boolean;
+  memberCount: number;
+  days: WorkloadSchemeDayResponse[];
+}
+
+export interface WorkloadSchemeDayResponse {
+  day: string;
+  requiredSeconds: number;
+}

--- a/src/tempo.ts
+++ b/src/tempo.ts
@@ -3,6 +3,7 @@ import AccountCategoryTypes from './collections/accountCategoryTypes';
 import AccountLinks from './collections/accountLinks';
 import Accounts from './collections/accounts';
 import Customers from './collections/customers';
+import HolidaySchemes from './collections/holidaySchemes';
 import Periods from './collections/periods';
 import Plans from './collections/plans';
 import Programs from './collections/programs';
@@ -13,6 +14,7 @@ import Teams from './collections/teams';
 import TimesheetApprovals from './collections/timesheetApprovals';
 import UserSchedule from './collections/userSchedule';
 import WorkAttributes from './collections/workAttributes';
+import WorkloadSchemes from './collections/workloadSchemes';
 import Worklogs from './collections/worklogs';
 import * as QueryOptionTypes from './queryOptionTypes';
 import RequestBuilder from './request/builder';
@@ -46,6 +48,8 @@ export default class TempoApi {
 
   public readonly customers: Customers;
 
+  public readonly holidaySchemes: HolidaySchemes;
+
   public readonly periods: Periods;
 
   public readonly plans: Plans;
@@ -66,6 +70,8 @@ export default class TempoApi {
 
   public readonly workAttributes: WorkAttributes;
 
+  public readonly workloadSchemes: WorkloadSchemes;
+
   public readonly worklogs: Worklogs;
 
   constructor(options: TempoApiOptions) {
@@ -79,6 +85,7 @@ export default class TempoApi {
     this.accountLinks = new AccountLinks(request);
     this.accounts = new Accounts(request);
     this.customers = new Customers(request);
+    this.holidaySchemes = new HolidaySchemes(request);
     this.periods = new Periods(request);
     this.plans = new Plans(request);
     this.programs = new Programs(request);
@@ -89,6 +96,7 @@ export default class TempoApi {
     this.timesheetApprovals = new TimesheetApprovals(request);
     this.userSchedule = new UserSchedule(request);
     this.workAttributes = new WorkAttributes(request);
+    this.workloadSchemes = new WorkloadSchemes(request);
     this.worklogs = new Worklogs(request);
   }
 }

--- a/tests/__snapshots__/tempoDocumentation.test.ts.snap
+++ b/tests/__snapshots__/tempoDocumentation.test.ts.snap
@@ -1,189 +1,189 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tempo REST API Documentation has not changed 1`] = `
-"<!DOCTYPE HTML><html><head><title>REST API documentation</title><meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\"><meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=utf-8\\"><meta name=\\"generator\\" content=\\"https://github.com/raml2html/raml2html 7.3.0\\"><link rel=\\"stylesheet\\" href=\\"https://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css\\"><link rel=\\"stylesheet\\" href=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/styles/default.min.css\\"><script type=\\"text/javascript\\" src=\\"https://code.jquery.com/jquery-1.11.0.min.js\\"></script><script type=\\"text/javascript\\" src=\\"https://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js\\"></script><script type=\\"text/javascript\\" src=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/highlight.min.js\\"></script><script type=\\"text/javascript\\">
-  $(document).ready(function() {
-    $('.page-header pre code, .top-resource-description pre code').each(function(i, block) {
-      hljs.highlightBlock(block);
-    });
+"<!DOCTYPE HTML><html><head><title>REST API documentation</title><meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\"><meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=utf-8\\"><meta name=\\"generator\\" content=\\"https://github.com/raml2html/raml2html 7.5.0\\"><link rel=\\"stylesheet\\" href=\\"https://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css\\"><link rel=\\"stylesheet\\" href=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/styles/default.min.css\\"><script type=\\"text/javascript\\" src=\\"https://code.jquery.com/jquery-1.11.0.min.js\\"></script><script type=\\"text/javascript\\" src=\\"https://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js\\"></script><script type=\\"text/javascript\\" src=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/highlight.min.js\\"></script><script type=\\"text/javascript\\">
+      $(document).ready(function() {
+        $('.page-header pre code, .top-resource-description pre code').each(function(i, block) {
+          hljs.highlightBlock(block);
+        });
 
-    $('[data-toggle]').click(function(e) {
-      e.preventDefault();
-      var selector = $(this).data('target') + ' pre code';
-      $(selector).each(function(i, block) {
-        hljs.highlightBlock(block);
+        $('[data-toggle]').click(function(e) {
+          e.preventDefault();
+          var selector = $(this).data('target') + ' pre code';
+          $(selector).each(function(i, block) {
+            hljs.highlightBlock(block);
+          });
+        });
       });
-    });
-  });
-</script><style>
-  .hljs {
-    background: transparent;
-  }
-  .parent {
-    color: #999;
-  }
-  .list-group-item > .badge {
-    float: none;
-    margin-right: 6px;
-  }
-  .panel-heading > .methods {
-    float: right;
-  }
-  .badge {
-    border-radius: 0;
-    text-transform: uppercase;
-    width: 70px;
-    font-weight: normal;
-    color: #f3f3f6;
-    line-height: normal;
-  }
-  .badge_get {
-    background-color: #63a8e2;
-  }
-  .badge_post {
-    background-color: #6cbd7d;
-  }
-  .badge_put {
-    background-color: #22bac4;
-  }
-  .badge_delete {
-    background-color: #d26460;
-  }
-  .badge_patch {
-    background-color: #ccc444;
-  }
-  .list-group, .panel-group {
-    margin-bottom: 0;
-  }
-  .panel-group .panel+.panel-white {
-    margin-top: 0;
-  }
-  .panel-group .panel-white {
-    border-bottom: 1px solid #F5F5F5;
-    border-radius: 0;
-  }
-  .panel-white:last-child {
-    border-bottom-color: white;
-    -webkit-box-shadow: none;
-    box-shadow: none;
-  }
-  .panel-white .panel-heading {
-    background: white;
-  }
-  .tab-pane ul {
-    padding-left: 2em;
-  }
-  .tab-pane h1 {
-    font-size: 1.3em;
-  }
-  .tab-pane h2 {
-    font-size: 1.2em;
-    padding-bottom: 4px;
-    border-bottom: 1px solid #ddd;
-  }
-  .tab-pane h3 {
-    font-size: 1.1em;
-  }
-  .tab-content {
-    border-left: 1px solid #ddd;
-    border-right: 1px solid #ddd;
-    border-bottom: 1px solid #ddd;
-    padding: 10px;
-  }
-  #sidebar {
-    margin-top: 30px;
-    padding-right: 5px;
-    overflow: auto;
-    height: 90%;
-  }
-  .top-resource-description {
-    border-bottom: 1px solid #ddd;
-    background: #fcfcfc;
-    padding: 15px 15px 0 15px;
-    margin: -15px -15px 10px -15px;
-  }
-  .resource-description {
-    border-bottom: 1px solid #fcfcfc;
-    background: #fcfcfc;
-    padding: 15px 15px 0 15px;
-    margin: -15px -15px 10px -15px;
-  }
-  .resource-description p:last-child {
-    margin: 0;
-  }
-  .list-group .badge {
-    float: left;
-  }
-  .method_description {
-    margin-left: 85px;
-  }
-  .method_description p:last-child {
-    margin: 0;
-  }
-  .list-group-item {
-    /*cursor: pointer;*/
-    border: none;
-    padding: 0;
-    margin-bottom: 30px;
-  }
-  pre code {
-    overflow: auto;
-    word-wrap: normal;
-    white-space: pre;
-  }
-  .items {
-    background: #f5f5f5;
-    color: #333;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    padding: 9.5px;
-    margin: 0 0 10px;
-    font-size: 13px;
-    line-height: 1.42857143;
-  }
-  .examples {
-    margin-left: 0.5em;
-  }
-  .resource-modal li > ul {
-    margin-bottom: 1em;
-  }
-  .resource_method_title {
-    margin-bottom: 10px;
-  }
-  .sg-nav__spacer {
-    padding-top: 30px;
-  }
-</style><link href=\\"https://fonts.googleapis.com/css?family=Open+Sans:300,400,700\\" rel=\\"stylesheet\\"><link rel=\\"stylesheet\\" href=\\"main.css\\"></head><body data-spy=\\"scroll\\" data-target=\\"#sidebar\\"><article class=\\"sg\\"><nav class=\\"sg-section sg-section--nav\\" style=\\"overflow-y: auto;\\"><div class=\\"sg-nav\\"><img class=\\"sg-nav__logo\\" src=\\"logo.png\\" alt=\\"TEMPO REST API\\" width=\\"179\\" height=\\"46\\"><div>REST API version 3</div><ul class=\\"sg-nav__links\\"><li class=\\"sg-nav__links__element\\"><a href=\\"#accounts\\">Accounts</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#account_categories\\">Account - Categories</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#account_category_types\\">Account - Category - Types</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#account_links\\">Account - Links</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#customers\\">Customers</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#plans\\">Plans</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#programs\\">Programs</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#roles\\">Roles</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#teams\\">Teams</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#team_links\\">Team - Links</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#team_memberships\\">Team - Memberships</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#periods\\">Periods</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#timesheet_approvals\\">Timesheet Approvals</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#user_schedule\\">User Schedule</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#work_attributes\\">Work Attributes</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#worklogs\\">Worklogs</a></li></ul><div class=\\"sg-nav__spacer\\">Servlet API</div><ul class=\\"sg-nav__links\\"><li class=\\"sg-nav__links__element\\"><a href=\\"https://tempo-io.github.io/tempo-mtm-docs/\\">Endpoints</a></li></ul><div class=\\"sg-nav__spacer\\">Audit API</div><ul class=\\"sg-nav__links\\"><li class=\\"sg-nav__links__element\\"><a href=\\"https://tempo-io.github.io/tempo-audit-docs/\\">Endpoints</a></li></ul></div></nav><section class=\\"sg-section sg-section--main\\"><div class=\\"sg-content\\"><h1 class=\\"sg-h1\\">REST API documentation <small>version 3</small></h1><p class=\\"sg-p\\">https://api.tempo.io/core/{version}</p><p class=\\"sg-p\\"></p><h3>About the Tempo REST API</h3><p class=\\"sg-p\\"><strong>Version 3 of the Tempo REST API is available as of February 1st, 2019.</strong></p><p class=\\"sg-p\\"><strong>As of March 29th, 2019, version 2 has been decomissioned. Everyone using the API is encouraged to switch to version 3.</strong></p><p class=\\"sg-p\\"><strong>For more information, see <a href=\\"https://tempo-io.atlassian.net/wiki/spaces/CLOUDNEWS/pages/358810021/2018-12-07+Action+Required+for+API+Users+Jira+Cloud+Privacy+Updates\\">this announcement</a>.</strong></p><p class=\\"sg-p\\">The REST API is designed around a flexible and scalable architecture that will extend in lockstep with Tempo’s development.</p><p class=\\"sg-p\\">We encourage you to join our developer community on Slack at <a href=\\"https://www.tempo.io/developers\\">www.tempo.io/developers</a>, where you can get support from our internal experts and share best practices with other developers building with Tempo.</p><p class=\\"sg-p\\">If you have feedback or requests, you can also reach us through the <a href=\\"https://tempo-io.atlassian.net/servicedesk/customer/portal/6\\">Tempo Help Center</a>.</p><h3>Changes from version 2</h3><h4>Privacy improvements</h4><p class=\\"sg-p\\">All APIs that previously used a username to identify users now use accountId instead. Field names in JSON documents have changed accordingly, for example <code>leadUsername</code> has been replaced with <code>leadAccountId</code>.</p><h4>Account contact</h4><p class=\\"sg-p\\">When creating an account, separate fields are used to identify the contact depending on whether the contact is a registered Jira user.</p><p class=\\"sg-p\\">The <code>contactAccountId</code> field is used to identify the contact if the contact is a registered Jira user. The <code>externalContactName</code> field is used if the contact is not a registered Jira user.</p><p class=\\"sg-p\\">In account responses, a new <code>type</code> field marks the contact as a Jira user (USER) or not (EXTERNAL).</p><h4>Team permission update</h4><p class=\\"sg-p\\">The API for updating team permissions has been removed.</p><h3>Using the REST API as an individual user</h3><p class=\\"sg-p\\">You can use the REST API to interact with the data your permissions give you access to. To do so, you will need to generate a Tempo OAuth 2.0 token.</p><p class=\\"sg-p\\">Go to <b>Tempo>Settings</b> and select <b>API integration</b>.</p><p class=\\"sg-p\\">Refer to <a href=\\"https://tempo-io.atlassian.net/wiki/spaces/TEMPO/pages/199065601/How+to+use+Tempo+Cloud+REST+APIs\\">Using REST API Integrations</a> for more information.</p><p class=\\"sg-p\\">Once you have a token, you need to use it inside the Authorization HTTP header. Ex:<pre>curl -v -H \\"Authorization: Bearer \${token}\\" \\"https://api.tempo.io/core/3/worklogs?...\\"</pre></p><h3>Using the REST API as an application developer</h3><p class=\\"sg-p\\">If you are building apps with Tempo, and have the required Tempo administrator permissions, you can quickly obtain the OAuth 2.0 credentials you need to retrieve an access token.</p><h4>Obtain your credentials</h4><p class=\\"sg-p\\">Go to <b>Tempo>Settings</b>, scroll down to <b>Developer Tools</b> and select <b>OAuth 2.0 authentication</b>.</p><p class=\\"sg-p\\">Enter a <i>Redirect URI</i> and specify the <i>Client type</i> and <i>Authorization grant type</i>. In most cases you will choose <i>Authorization code</i> as the Authorization grant type.</p><p class=\\"sg-p\\">Once you click <b>Add</b>, your Client ID and Client secret are generated and you can retrieve your access token.</p><p class=\\"sg-p\\">Refer to <a href=\\"https://tempo-io.atlassian.net/wiki/spaces/TEMPO/pages/192839693/To+generate+credentials+for+access+to+Tempo+data\\">Using OAuth 2.0 authentication</a> for more information about generating your credentials.</p><h3>How to retrieve an access token for a user</h3><h4>Authorization grant type used is <i>authorization_code</i></h4><h5>Step 1</h5><p class=\\"sg-p\\">Obtain an authorization code against your JIRA Cloud instance :<pre>GET: https://{jira-cloud-instance-name}.atlassian.net/plugins/servlet/ac/io.tempo.jira/oauth-authorize/?client_id=\${CLIENT_ID}&redirect_uri=\${REDIRECT_URI}&access_type=tenant_user</pre></p><p class=\\"sg-p\\">Where <i>\${CLIENT_ID}</i> and <i>\${REDIRECT_URI}</i> match the one you generated in <b>Tempo > Settings > OAuth 2.0 Applications</b></p><p class=\\"sg-p\\">You will be asked to <b>authorize</b> or <b>deny</b> access to your Tempo data. Granting access redirects you to the configured <i>redirect URI</i> with a new query string parameter named <i>code</i> (this is the authorization code). Note that this authorization code expires quickly.</p><p class=\\"sg-p\\"><img src=\\"myapp-request-access.png\\" title=\\"MyApp Request Access\\"></p><h5>Step 2</h5><p class=\\"sg-p\\">Obtain an access token from Tempo by providing the <i>authorization code</i> to:<pre>POST: https://api.tempo.io/oauth/token/</pre>sending the following parameters using the \\"application/x-www-form-urlencoded\\" format:<pre>
+    </script><style>
+      .hljs {
+        background: transparent;
+      }
+      .parent {
+        color: #999;
+      }
+      .list-group-item > .badge {
+        float: none;
+        margin-right: 6px;
+      }
+      .panel-heading > .methods {
+        float: right;
+      }
+      .badge {
+        border-radius: 0;
+        text-transform: uppercase;
+        width: 70px;
+        font-weight: normal;
+        color: #f3f3f6;
+        line-height: normal;
+      }
+      .badge_get {
+        background-color: #63a8e2;
+      }
+      .badge_post {
+        background-color: #6cbd7d;
+      }
+      .badge_put {
+        background-color: #22bac4;
+      }
+      .badge_delete {
+        background-color: #d26460;
+      }
+      .badge_patch {
+        background-color: #ccc444;
+      }
+      .list-group, .panel-group {
+        margin-bottom: 0;
+      }
+      .panel-group .panel+.panel-white {
+        margin-top: 0;
+      }
+      .panel-group .panel-white {
+        border-bottom: 1px solid #F5F5F5;
+        border-radius: 0;
+      }
+      .panel-white:last-child {
+        border-bottom-color: white;
+        -webkit-box-shadow: none;
+        box-shadow: none;
+      }
+      .panel-white .panel-heading {
+        background: white;
+      }
+      .tab-pane ul {
+        padding-left: 2em;
+      }
+      .tab-pane h1 {
+        font-size: 1.3em;
+      }
+      .tab-pane h2 {
+        font-size: 1.2em;
+        padding-bottom: 4px;
+        border-bottom: 1px solid #ddd;
+      }
+      .tab-pane h3 {
+        font-size: 1.1em;
+      }
+      .tab-content {
+        border-left: 1px solid #ddd;
+        border-right: 1px solid #ddd;
+        border-bottom: 1px solid #ddd;
+        padding: 10px;
+      }
+      #sidebar {
+        margin-top: 30px;
+        padding-right: 5px;
+        overflow: auto;
+        height: 90%;
+      }
+      .top-resource-description {
+        border-bottom: 1px solid #ddd;
+        background: #fcfcfc;
+        padding: 15px 15px 0 15px;
+        margin: -15px -15px 10px -15px;
+      }
+      .resource-description {
+        border-bottom: 1px solid #fcfcfc;
+        background: #fcfcfc;
+        padding: 15px 15px 0 15px;
+        margin: -15px -15px 10px -15px;
+      }
+      .resource-description p:last-child {
+        margin: 0;
+      }
+      .list-group .badge {
+        float: left;
+      }
+      .method_description {
+        margin-left: 85px;
+      }
+      .method_description p:last-child {
+        margin: 0;
+      }
+      .list-group-item {
+        /*cursor: pointer;*/
+        border: none;
+        padding: 0;
+        margin-bottom: 30px;
+      }
+      pre code {
+        overflow: auto;
+        word-wrap: normal;
+        white-space: pre;
+      }
+      .items {
+        background: #f5f5f5;
+        color: #333;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        padding: 9.5px;
+        margin: 0 0 10px;
+        font-size: 13px;
+        line-height: 1.42857143;
+      }
+      .examples {
+        margin-left: 0.5em;
+      }
+      .resource-modal li > ul {
+        margin-bottom: 1em;
+      }
+      .resource_method_title {
+        margin-bottom: 10px;
+      }
+      .sg-nav__spacer {
+        padding-top: 30px;
+      }
+    </style><link href=\\"https://fonts.googleapis.com/css?family=Open+Sans:300,400,700\\" rel=\\"stylesheet\\"><link rel=\\"stylesheet\\" href=\\"main.css\\"></head><body data-spy=\\"scroll\\" data-target=\\"#sidebar\\"><article class=\\"sg\\"><nav class=\\"sg-section sg-section--nav\\" style=\\"overflow-y: auto;\\"><div class=\\"sg-nav\\"><img class=\\"sg-nav__logo\\" src=\\"logo.png\\" alt=\\"TEMPO REST API\\" width=\\"179\\" height=\\"46\\"><div>REST API version 3</div><ul class=\\"sg-nav__links\\"><li class=\\"sg-nav__links__element\\"><a href=\\"#accounts\\">Accounts</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#account_categories\\">Account - Categories</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#account_category_types\\">Account - Category - Types</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#account_links\\">Account - Links</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#customers\\">Customers</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#plans\\">Plans</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#programs\\">Programs</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#roles\\">Roles</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#teams\\">Teams</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#team_links\\">Team - Links</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#team_memberships\\">Team - Memberships</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#periods\\">Periods</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#timesheet_approvals\\">Timesheet Approvals</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#user_schedule\\">User Schedule</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#work_attributes\\">Work Attributes</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#workload_schemes\\">Workload Schemes</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#holiday_schemes\\">Holiday Schemes</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#worklogs\\">Worklogs</a></li></ul><div class=\\"sg-nav__spacer\\">Servlet API</div><ul class=\\"sg-nav__links\\"><li class=\\"sg-nav__links__element\\"><a href=\\"https://tempo-io.github.io/tempo-mtm-docs/\\">Endpoints</a></li></ul><div class=\\"sg-nav__spacer\\">Audit API</div><ul class=\\"sg-nav__links\\"><li class=\\"sg-nav__links__element\\"><a href=\\"https://tempo-io.github.io/tempo-audit-docs/\\">Endpoints</a></li></ul></div></nav><section class=\\"sg-section sg-section--main\\"><div class=\\"sg-content\\"><h1 class=\\"sg-h1\\">REST API documentation <small>version 3</small></h1><p class=\\"sg-p\\">https://api.tempo.io/core/{version}</p><p class=\\"sg-p\\"></p><h3>About the Tempo REST API</h3><p class=\\"sg-p\\"><strong>Version 3 of the Tempo REST API is available as of February 1st, 2019.</strong></p><p class=\\"sg-p\\"><strong>As of March 29th, 2019, version 2 has been decomissioned. Everyone using the API is encouraged to switch to version 3.</strong></p><p class=\\"sg-p\\"><strong>For more information, see <a href=\\"https://tempo-io.atlassian.net/wiki/spaces/CLOUDNEWS/pages/358810021/2018-12-07+Action+Required+for+API+Users+Jira+Cloud+Privacy+Updates\\">this announcement</a>.</strong></p><p class=\\"sg-p\\">The REST API is designed around a flexible and scalable architecture that will extend in lockstep with Tempo’s development.</p><p class=\\"sg-p\\">We encourage you to join our developer community on Slack at <a href=\\"https://www.tempo.io/developers\\">www.tempo.io/developers</a>, where you can get support from our internal experts and share best practices with other developers building with Tempo.</p><p class=\\"sg-p\\">If you have feedback or requests, you can also reach us through the <a href=\\"https://tempo-io.atlassian.net/servicedesk/customer/portal/6\\">Tempo Help Center</a>.</p><h3>Changes from version 2</h3><h4>Privacy improvements</h4><p class=\\"sg-p\\">All APIs that previously used a username to identify users now use accountId instead. Field names in JSON documents have changed accordingly, for example <code>leadUsername</code> has been replaced with <code>leadAccountId</code>.</p><h4>Account contact</h4><p class=\\"sg-p\\">When creating an account, separate fields are used to identify the contact depending on whether the contact is a registered Jira user.</p><p class=\\"sg-p\\">The <code>contactAccountId</code> field is used to identify the contact if the contact is a registered Jira user. The <code>externalContactName</code> field is used if the contact is not a registered Jira user.</p><p class=\\"sg-p\\">In account responses, a new <code>type</code> field marks the contact as a Jira user (USER) or not (EXTERNAL).</p><h4>Team permission update</h4><p class=\\"sg-p\\">The API for updating team permissions has been removed.</p><h3>Using the REST API as an individual user</h3><p class=\\"sg-p\\">You can use the REST API to interact with the data your permissions give you access to. To do so, you will need to generate a Tempo OAuth 2.0 token.</p><p class=\\"sg-p\\">Go to <b>Tempo>Settings</b> and select <b>API integration</b>.</p><p class=\\"sg-p\\">Once you have a token, you need to use it inside the Authorization HTTP header. Ex:<pre>curl -v -H \\"Authorization: Bearer $token\\" \\"https://api.tempo.io/core/3/worklogs?...\\"</pre></p><h3>Using the REST API as an application developer</h3><p class=\\"sg-p\\">If you are building apps with Tempo, and have the required Tempo administrator permissions, you can quickly obtain the OAuth 2.0 credentials you need to retrieve an access token.</p><h4>Obtain your credentials</h4><p class=\\"sg-p\\">Go to <b>Tempo>Settings</b>, scroll down to <b>Developer Tools</b> and select <b>OAuth 2.0 authentication</b>.</p><p class=\\"sg-p\\">Enter a <i>Redirect URI</i> and specify the <i>Client type</i> and <i>Authorization grant type</i>. In most cases you will choose <i>Authorization code</i> as the Authorization grant type.</p><p class=\\"sg-p\\">Once you click <b>Add</b>, your Client ID and Client secret are generated and you can retrieve your access token.</p><h3>How to retrieve an access token for a user</h3><h4>Authorization grant type used is <i>authorization_code</i></h4><h5>Step 1</h5><p class=\\"sg-p\\">Obtain an authorization code against your JIRA Cloud instance :<pre>GET: https://{jira-cloud-instance-name}.atlassian.net/plugins/servlet/ac/io.tempo.jira/oauth-authorize/?client_id=$CLIENT_ID&redirect_uri=$REDIRECT_URI&access_type=tenant_user</pre></p><p class=\\"sg-p\\">Where <i>$CLIENT_ID</i> and <i>$REDIRECT_URI</i> match the one you generated in <b>Tempo > Settings > OAuth 2.0 Applications</b></p><p class=\\"sg-p\\">You will be asked to <b>authorize</b> or <b>deny</b> access to your Tempo data. Granting access redirects you to the configured <i>redirect URI</i> with a new query string parameter named <i>code</i> (this is the authorization code). Note that this authorization code expires quickly.</p><p class=\\"sg-p\\"><img src=\\"myapp-request-access.png\\" title=\\"MyApp Request Access\\"></p><h5>Step 2</h5><p class=\\"sg-p\\">Obtain an access token from Tempo by providing the <i>authorization code</i> to:<pre>POST: https://api.tempo.io/oauth/token/</pre>sending the following parameters using the \\"application/x-www-form-urlencoded\\" format:<pre>
    grant_type = \\"authorization_code\\"
-   client_id = \${CLIENT_ID}
-   client_secret = \${CLIENT_SECRET}
-   redirect_uri = \${REDIRECT_URI}
+   client_id = $CLIENT_ID
+   client_secret = $CLIENT_SECRET
+   redirect_uri = $REDIRECT_URI
    code = $CODE
 </pre></p><p class=\\"sg-p\\">The response includes the access token itself, related information, and a refresh token.<pre>
 {
-   \\"access_token\\":\\"\${ACCESS_TOKEN}\\",
+   \\"access_token\\":\\"$ACCESS_TOKEN\\",
    \\"expires_in\\":5184000,
    \\"token_type\\":\\"Bearer\\",
    \\"scope\\":\\"read write\\",
-   \\"refresh_token\\":\\"\${REFRESH_TOKEN}\\"
+   \\"refresh_token\\":\\"$REFRESH_TOKEN\\"
 }
-</pre></p><h5>Step 3</h5><p class=\\"sg-p\\">Provide this <i>access token</i> to any API requests using the <i>Authorization header</i> :<pre>curl -H \\"Authorization: Bearer \${ACCESS_TOKEN}\\" \\"https://api.tempo.io/core/3/worklogs?from=2018-01-28&to=2018-02-03\\"</pre></p><h3>How to retrieve a new access token from the refresh token</h3><p class=\\"sg-p\\">The <i>access token</i> will eventually expire. You need to renew it using the previously received <i>refresh token</i>Æ<pre>POST: https://api.tempo.io/oauth/token/</pre>sending the following parameters using the \\"application/x-www-form-urlencoded\\" format:<pre>
+</pre></p><h5>Step 3</h5><p class=\\"sg-p\\">Provide this <i>access token</i> to any API requests using the <i>Authorization header</i> :<pre>curl -H \\"Authorization: Bearer $ACCESS_TOKEN\\" \\"https://api.tempo.io/core/3/worklogs?from=2018-01-28&to=2018-02-03\\"</pre></p><h3>How to retrieve a new access token from the refresh token</h3><p class=\\"sg-p\\">The <i>access token</i> will eventually expire. You need to renew it using the previously received <i>refresh token</i>Æ<pre>POST: https://api.tempo.io/oauth/token/</pre>sending the following parameters using the \\"application/x-www-form-urlencoded\\" format:<pre>
    grant_type = \\"refresh_token\\"
-   client_id = \${CLIENT_ID}
-   client_secret = \${CLIENT_SECRET}
-   redirect_uri = \${REDIRECT_URI}
-   refresh_token = \${REFRESH_TOKEN}
+   client_id = $CLIENT_ID
+   client_secret = $CLIENT_SECRET
+   redirect_uri = $REDIRECT_URI
+   refresh_token = $REFRESH_TOKEN
 </pre></p><p class=\\"sg-p\\">The response will contain a new <i>access token</i> and a new <i>refresh token</i>.</p><h3>How to revoke a token</h3><p class=\\"sg-p\\">You can revoke an existing <i>access token</i> at any time:<pre>POST: https://api.tempo.io/oauth/revoke_token/</pre>sending the following parameters using the \\"application/x-www-form-urlencoded\\" format:<pre>
    token_type_hint = \\"access_token\\"
-   client_id = \${CLIENT_ID}
-   client_secret = \${CLIENT_SECRET}
-   token = \${ACCESS_TOKEN}
+   client_id = $CLIENT_ID
+   client_secret = $CLIENT_SECRET
+   token = $ACCESS_TOKEN
 </pre></p><p class=\\"sg-p\\">You can also revoke an existing <i>refresh token</i>:<pre>POST: https://api.tempo.io/oauth/revoke_token/</pre>sending the following parameters using the \\"application/x-www-form-urlencoded\\" format:<pre>
 {
    token_type_hint = \\"refresh_token\\"
-   client_id = \${CLIENT_ID}
-   client_secret = \${CLIENT_SECRET}
-   token = \${REFRESH_TOKEN}
+   client_id = $CLIENT_ID
+   client_secret = $CLIENT_SECRET
+   token = $REFRESH_TOKEN
 }
 </pre></p><h3>API conventions</h3><h4>Identifying users</h4><p class=\\"sg-p\\">The Tempo REST API uses the Atlassian accountId to identify users. The accountId is an opaque identifier that uniquely identifies the user.</p><p class=\\"sg-p\\">The accountId of the current user can found using the <a href=\\"https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-group-Myself\\">Jira Myself API</a>.</p><p class=\\"sg-p\\">Information about a user, given the accountId, can be retrieved using the <a href=\\"https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-group-User\\">Jira User API</a>.</p><h4>Dates</h4><p class=\\"sg-p\\">The API uses strings to represent dates. Dates are formatted as <a href=\\"https://en.wikipedia.org/wiki/ISO_8601#Calendar_dates\\">ISO 8601 calendar dates</a> (YYYY-MM-DD). For example, March 29th, 2019 is formatted as 2019-03-29.</p><h4>Delete requests</h4><p class=\\"sg-p\\">On success, delete requests return a response with status code <a href=\\"https://httpstatuses.com/204\\">204 (No content)</a>. No payload body is included in the response.</p><p></p><ul><li><strong>version</strong>: <em>required (3)</em></li></ul><h2 class=\\"sg-h2\\" id=\\"accounts\\">Accounts</h2><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_accounts\\" href=\\"#panel_accounts\\"><span class=\\"parent\\"></span>/accounts</a> <span class=\\"methods\\"><span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_accounts\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Creates a new account.</p><p>Separate fields are used to identify the contact depending on whether the contact is a registered Jira user or not. The <code>contactAccountId</code> field is used to identify the contact if the contact is a registered Jira user. The <code>externalContactName</code> field is used if the contact is not a registered Jira user.</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#accounts_post_request\\" data-toggle=\\"tab\\">Request</a></li><li><a href=\\"#accounts_post_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#accounts_post_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"accounts_post_request\\"><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>key</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>status</strong>: <em>required (one of OPEN, CLOSED, ARCHIVED)</em></li><li><strong>leadAccountId</strong>: <em>required (string)</em></li><li><strong>contactAccountId</strong>: <em>(string)</em><p>accountId of the contact, if the contact is a registered Jira user</p></li><li><strong>externalContactName</strong>: <em>(string)</em><p>Name of the contact, if the contact is not a registered Jira user</p></li><li><strong>categoryKey</strong>: <em>(string)</em></li><li><strong>customerKey</strong>: <em>(string)</em></li><li><strong>monthlyBudget</strong>: <em>(number)</em></li><li><strong>global</strong>: <em>(boolean - default: false)</em></li></ul><p><strong>Examples</strong>:</p><div class=\\"examples\\"><p><strong>Jira user as contact</strong>:<br></p><pre><code>{
   \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
@@ -1033,7 +1033,7 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
     }
   ]
 }
-</code></pre></div></div><div class=\\"tab-pane\\" id=\\"customers__key__accounts_get_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div><h2 class=\\"sg-h2\\" id=\\"plans\\">Plans</h2><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_plans\\" href=\\"#panel_plans\\"><span class=\\"parent\\"></span>/plans</a> <span class=\\"methods\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_plans\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Retrieve plans</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#plans_get_request\\" data-toggle=\\"tab\\">Request</a></li><li><a href=\\"#plans_get_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#plans_get_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"plans_get_request\\"><h3>Query Parameters</h3><ul><li><strong>assigneeType</strong>: <em>(string)</em><p>Retrieve only plans with assignees of the given type.</p></li><li><strong>planItemType</strong>: <em>(string)</em><p>Retrieve only plans with plan items of the given type.</p></li><li><strong>from</strong>: <em>required (date-only)</em><p>Retrieve results starting with this date</p></li><li><strong>to</strong>: <em>required (date-only)</em><p>Retrieve results up to and including this date</p></li><li><strong>updatedFrom</strong>: <em>(date-only)</em><p>Retrieve results that have been updated from this date</p></li><li><strong>offset?</strong>: <em>(integer - default: 0)</em><p>Skip over a number of elements by specifying an offset value for the query</p></li><li><strong>limit?</strong>: <em>(integer - default: 50 - maximum: 1000)</em><p>Limit the number of elements on the response</p></li></ul></div><div class=\\"tab-pane\\" id=\\"plans_get_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>offset</strong>: <em>required (integer - default: 0)</em></li><li><strong>limit</strong>: <em>required (integer - default: 50 - maximum: 1000)</em></li><li><strong>next</strong>: <em>(string)</em></li><li><strong>previous</strong>: <em>(string)</em></li></ul></li><li><strong>results</strong>: <em>required (array of Plan)</em><p><strong>Items</strong>: Plan</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>endDate</strong>: <em>required (date-only)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>assignee</strong>: <em>required (assignee)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, TEAM)</em></li></ul></li><li><strong>planItem</strong>: <em>required (planItem)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of ISSUE, PROJECT)</em></li></ul></li><li><strong>recurrence</strong>: <em>required (recurrence)</em><ul><li><strong>rule</strong>: <em>required (one of NEVER, WEEKLY, BIWEEKLY, MONTHLY)</em></li><li><strong>recurrenceEndDate</strong>: <em>required (date-only)</em></li></ul></li><li><strong>dates</strong>: <em>required (dates)</em><ul><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>all</strong>: <em>required (string)</em></li></ul></li><li><strong>values</strong>: <em>required (array of PlanPeriod)</em><p><strong>Items</strong>: PlanPeriod</p><div class=\\"items\\"><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li><li><strong>timePlannedSeconds</strong>: <em>required (number)</em></li></ul></div></li></ul></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+</code></pre></div></div><div class=\\"tab-pane\\" id=\\"customers__key__accounts_get_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div><h2 class=\\"sg-h2\\" id=\\"plans\\">Plans</h2><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_plans\\" href=\\"#panel_plans\\"><span class=\\"parent\\"></span>/plans</a> <span class=\\"methods\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_plans\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Retrieve plans</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#plans_get_request\\" data-toggle=\\"tab\\">Request</a></li><li><a href=\\"#plans_get_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#plans_get_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"plans_get_request\\"><h3>Query Parameters</h3><ul><li><strong>assigneeType</strong>: <em>(string)</em><p>Retrieve only plans with assignees of the given type.</p></li><li><strong>planItemType</strong>: <em>(string)</em><p>Retrieve only plans with plan items of the given type.</p></li><li><strong>from</strong>: <em>required (date-only)</em><p>Retrieve results starting with this date</p></li><li><strong>to</strong>: <em>required (date-only)</em><p>Retrieve results up to and including this date</p></li><li><strong>updatedFrom</strong>: <em>(date-only)</em><p>Retrieve results that have been updated from this date</p></li><li><strong>offset?</strong>: <em>(integer - default: 0)</em><p>Skip over a number of elements by specifying an offset value for the query</p></li><li><strong>limit?</strong>: <em>(integer - default: 50 - maximum: 1000)</em><p>Limit the number of elements on the response</p></li></ul></div><div class=\\"tab-pane\\" id=\\"plans_get_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>offset</strong>: <em>required (integer - default: 0)</em></li><li><strong>limit</strong>: <em>required (integer - default: 50 - maximum: 1000)</em></li><li><strong>next</strong>: <em>(string)</em></li><li><strong>previous</strong>: <em>(string)</em></li></ul></li><li><strong>results</strong>: <em>required (array of Plan)</em><p><strong>Items</strong>: Plan</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>endDate</strong>: <em>required (date-only)</em></li><li><strong>secondsPerDay</strong>: <em>required (number)</em></li><li><strong>includeNonWorkingDays</strong>: <em>required (boolean)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>assignee</strong>: <em>required (assignee)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, TEAM)</em></li></ul></li><li><strong>planItem</strong>: <em>required (planItem)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of ISSUE, PROJECT)</em></li></ul></li><li><strong>recurrence</strong>: <em>required (recurrence)</em><ul><li><strong>rule</strong>: <em>required (one of NEVER, WEEKLY, BIWEEKLY, MONTHLY)</em></li><li><strong>recurrenceEndDate</strong>: <em>required (date-only)</em></li></ul></li><li><strong>dates</strong>: <em>required (dates)</em><ul><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>all</strong>: <em>required (string)</em></li></ul></li><li><strong>values</strong>: <em>required (array of PlanPeriod)</em><p><strong>Items</strong>: PlanPeriod</p><div class=\\"items\\"><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li><li><strong>timePlannedSeconds</strong>: <em>required (number)</em></li></ul></div></li></ul></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
   \\"self\\": \\"https://api.tempo.io/core/3/plans?assigneeType=USER&amp;planItemType=ISSUE&amp;from=2017-11-01&amp;to=2017-12-31&amp;updatedFrom=2017-02-01&amp;offset=0&amp;limit=50\\",
   \\"metadata\\": {
     \\"count\\": 2,
@@ -1046,6 +1046,8 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
       \\"id\\": 223,
       \\"startDate\\": \\"2017-07-13\\",
       \\"endDate\\": \\"2017-11-13\\",
+      \\"secondsPerDay\\": 3600,
+      \\"includeNonWorkingDays\\": false,
       \\"description\\": \\"This is an issue plan\\",
       \\"createdAt\\": \\"2017-02-23T15:07:00Z\\",
       \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\",
@@ -1085,6 +1087,8 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
       \\"id\\": 289,
       \\"startDate\\": \\"2017-07-13\\",
       \\"endDate\\": \\"2017-11-13\\",
+      \\"secondsPerDay\\": 14400,
+      \\"includeNonWorkingDays\\": false,
       \\"description\\": \\"This is a project plan\\",
       \\"createdAt\\": \\"2017-02-23T15:07:00Z\\",
       \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\",
@@ -1156,11 +1160,13 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
   \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
   \\"issueKey\\": \\"ISS-15\\"
 }
-</code></pre></div></div><div class=\\"tab-pane\\" id=\\"plans_post_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>Plan has been successfully created</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>endDate</strong>: <em>required (date-only)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>assignee</strong>: <em>required (assignee)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, TEAM)</em></li></ul></li><li><strong>planItem</strong>: <em>required (planItem)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of ISSUE, PROJECT)</em></li></ul></li><li><strong>recurrence</strong>: <em>required (recurrence)</em><ul><li><strong>rule</strong>: <em>required (one of NEVER, WEEKLY, BIWEEKLY, MONTHLY)</em></li><li><strong>recurrenceEndDate</strong>: <em>required (date-only)</em></li></ul></li><li><strong>dates</strong>: <em>required (dates)</em><ul><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>all</strong>: <em>required (string)</em></li></ul></li><li><strong>values</strong>: <em>required (array of PlanPeriod)</em><p><strong>Items</strong>: PlanPeriod</p><div class=\\"items\\"><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li><li><strong>timePlannedSeconds</strong>: <em>required (number)</em></li></ul></div></li></ul></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+</code></pre></div></div><div class=\\"tab-pane\\" id=\\"plans_post_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>Plan has been successfully created</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>endDate</strong>: <em>required (date-only)</em></li><li><strong>secondsPerDay</strong>: <em>required (number)</em></li><li><strong>includeNonWorkingDays</strong>: <em>required (boolean)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>assignee</strong>: <em>required (assignee)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, TEAM)</em></li></ul></li><li><strong>planItem</strong>: <em>required (planItem)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of ISSUE, PROJECT)</em></li></ul></li><li><strong>recurrence</strong>: <em>required (recurrence)</em><ul><li><strong>rule</strong>: <em>required (one of NEVER, WEEKLY, BIWEEKLY, MONTHLY)</em></li><li><strong>recurrenceEndDate</strong>: <em>required (date-only)</em></li></ul></li><li><strong>dates</strong>: <em>required (dates)</em><ul><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>all</strong>: <em>required (string)</em></li></ul></li><li><strong>values</strong>: <em>required (array of PlanPeriod)</em><p><strong>Items</strong>: PlanPeriod</p><div class=\\"items\\"><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li><li><strong>timePlannedSeconds</strong>: <em>required (number)</em></li></ul></div></li></ul></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
   \\"self\\": \\"https://api.tempo.io/core/3/plans/123\\",
   \\"id\\": 123,
   \\"startDate\\": \\"2017-12-15\\",
   \\"endDate\\": \\"2017-12-15\\",
+  \\"secondsPerDay\\": 28800,
+  \\"includeNonWorkingDays\\": false,
   \\"description\\": \\"This is a plan\\",
   \\"createdAt\\": \\"2017-02-23T15:07:00Z\\",
   \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\",
@@ -1196,11 +1202,13 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
     }
   ]
 }
-</code></pre></div></div><div class=\\"tab-pane\\" id=\\"plans_post_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_plans__id_\\" href=\\"#panel_plans__id_\\"><span class=\\"parent\\">/plans</span>/{id}</a> <span class=\\"methods\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_plans__id_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Retrieve an existing plan for the given id. Add from and to query params to expand recurrences.</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#plans__id__get_request\\" data-toggle=\\"tab\\">Request</a></li><li><a href=\\"#plans__id__get_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#plans__id__get_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"plans__id__get_request\\"><h3>URI Parameters</h3><ul><li><strong>id</strong>: <em>required (string)</em></li></ul><h3>Query Parameters</h3><ul><li><strong>from</strong>: <em>(date-only)</em><p>Retrieve results starting with this date</p></li><li><strong>to</strong>: <em>(date-only)</em><p>Retrieve results up to and including this date</p></li></ul></div><div class=\\"tab-pane\\" id=\\"plans__id__get_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>Plan of the given id</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>endDate</strong>: <em>required (date-only)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>assignee</strong>: <em>required (assignee)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, TEAM)</em></li></ul></li><li><strong>planItem</strong>: <em>required (planItem)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of ISSUE, PROJECT)</em></li></ul></li><li><strong>recurrence</strong>: <em>required (recurrence)</em><ul><li><strong>rule</strong>: <em>required (one of NEVER, WEEKLY, BIWEEKLY, MONTHLY)</em></li><li><strong>recurrenceEndDate</strong>: <em>required (date-only)</em></li></ul></li><li><strong>dates</strong>: <em>required (dates)</em><ul><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>all</strong>: <em>required (string)</em></li></ul></li><li><strong>values</strong>: <em>required (array of PlanPeriod)</em><p><strong>Items</strong>: PlanPeriod</p><div class=\\"items\\"><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li><li><strong>timePlannedSeconds</strong>: <em>required (number)</em></li></ul></div></li></ul></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+</code></pre></div></div><div class=\\"tab-pane\\" id=\\"plans_post_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_plans__id_\\" href=\\"#panel_plans__id_\\"><span class=\\"parent\\">/plans</span>/{id}</a> <span class=\\"methods\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_plans__id_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Retrieve an existing plan for the given id. Add from and to query params to expand recurrences.</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#plans__id__get_request\\" data-toggle=\\"tab\\">Request</a></li><li><a href=\\"#plans__id__get_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#plans__id__get_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"plans__id__get_request\\"><h3>URI Parameters</h3><ul><li><strong>id</strong>: <em>required (string)</em></li></ul><h3>Query Parameters</h3><ul><li><strong>from</strong>: <em>(date-only)</em><p>Retrieve results starting with this date</p></li><li><strong>to</strong>: <em>(date-only)</em><p>Retrieve results up to and including this date</p></li></ul></div><div class=\\"tab-pane\\" id=\\"plans__id__get_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>Plan of the given id</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>endDate</strong>: <em>required (date-only)</em></li><li><strong>secondsPerDay</strong>: <em>required (number)</em></li><li><strong>includeNonWorkingDays</strong>: <em>required (boolean)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>assignee</strong>: <em>required (assignee)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, TEAM)</em></li></ul></li><li><strong>planItem</strong>: <em>required (planItem)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of ISSUE, PROJECT)</em></li></ul></li><li><strong>recurrence</strong>: <em>required (recurrence)</em><ul><li><strong>rule</strong>: <em>required (one of NEVER, WEEKLY, BIWEEKLY, MONTHLY)</em></li><li><strong>recurrenceEndDate</strong>: <em>required (date-only)</em></li></ul></li><li><strong>dates</strong>: <em>required (dates)</em><ul><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>all</strong>: <em>required (string)</em></li></ul></li><li><strong>values</strong>: <em>required (array of PlanPeriod)</em><p><strong>Items</strong>: PlanPeriod</p><div class=\\"items\\"><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li><li><strong>timePlannedSeconds</strong>: <em>required (number)</em></li></ul></div></li></ul></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
   \\"self\\": \\"https://api.tempo.io/core/3/plans/123\\",
   \\"id\\": 123,
   \\"startDate\\": \\"2017-12-15\\",
   \\"endDate\\": \\"2017-12-15\\",
+  \\"secondsPerDay\\": 28800,
+  \\"includeNonWorkingDays\\": false,
   \\"description\\": \\"This is a plan\\",
   \\"createdAt\\": \\"2017-02-23T15:07:00Z\\",
   \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\",
@@ -1252,11 +1260,13 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
   \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
   \\"issueKey\\": \\"ISS-15\\"
 }
-</code></pre></div></div><div class=\\"tab-pane\\" id=\\"plans__id__put_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>Plan has been successfully updated</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>endDate</strong>: <em>required (date-only)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>assignee</strong>: <em>required (assignee)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, TEAM)</em></li></ul></li><li><strong>planItem</strong>: <em>required (planItem)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of ISSUE, PROJECT)</em></li></ul></li><li><strong>recurrence</strong>: <em>required (recurrence)</em><ul><li><strong>rule</strong>: <em>required (one of NEVER, WEEKLY, BIWEEKLY, MONTHLY)</em></li><li><strong>recurrenceEndDate</strong>: <em>required (date-only)</em></li></ul></li><li><strong>dates</strong>: <em>required (dates)</em><ul><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>all</strong>: <em>required (string)</em></li></ul></li><li><strong>values</strong>: <em>required (array of PlanPeriod)</em><p><strong>Items</strong>: PlanPeriod</p><div class=\\"items\\"><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li><li><strong>timePlannedSeconds</strong>: <em>required (number)</em></li></ul></div></li></ul></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+</code></pre></div></div><div class=\\"tab-pane\\" id=\\"plans__id__put_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>Plan has been successfully updated</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>endDate</strong>: <em>required (date-only)</em></li><li><strong>secondsPerDay</strong>: <em>required (number)</em></li><li><strong>includeNonWorkingDays</strong>: <em>required (boolean)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>assignee</strong>: <em>required (assignee)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, TEAM)</em></li></ul></li><li><strong>planItem</strong>: <em>required (planItem)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of ISSUE, PROJECT)</em></li></ul></li><li><strong>recurrence</strong>: <em>required (recurrence)</em><ul><li><strong>rule</strong>: <em>required (one of NEVER, WEEKLY, BIWEEKLY, MONTHLY)</em></li><li><strong>recurrenceEndDate</strong>: <em>required (date-only)</em></li></ul></li><li><strong>dates</strong>: <em>required (dates)</em><ul><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>all</strong>: <em>required (string)</em></li></ul></li><li><strong>values</strong>: <em>required (array of PlanPeriod)</em><p><strong>Items</strong>: PlanPeriod</p><div class=\\"items\\"><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li><li><strong>timePlannedSeconds</strong>: <em>required (number)</em></li></ul></div></li></ul></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
   \\"self\\": \\"https://api.tempo.io/core/3/plans/123\\",
   \\"id\\": 123,
   \\"startDate\\": \\"2017-12-15\\",
   \\"endDate\\": \\"2017-12-15\\",
+  \\"secondsPerDay\\": 28800,
+  \\"includeNonWorkingDays\\": false,
   \\"description\\": \\"This is a plan\\",
   \\"createdAt\\": \\"2017-02-23T15:07:00Z\\",
   \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\",
@@ -1309,7 +1319,7 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
       \\"message\\": \\"Allocation not found\\"
     }
   ]
-}</code></pre></div></div><div class=\\"tab-pane\\" id=\\"plans__id__delete_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_plans_user__accountid_\\" href=\\"#panel_plans_user__accountid_\\"><span class=\\"parent\\">/plans</span>/user/{accountId}</a> <span class=\\"methods\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_plans_user__accountid_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Retrieve plans for user</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#plans_user__accountid__get_request\\" data-toggle=\\"tab\\">Request</a></li><li><a href=\\"#plans_user__accountid__get_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#plans_user__accountid__get_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"plans_user__accountid__get_request\\"><h3>URI Parameters</h3><ul><li><strong>accountId</strong>: <em>required (string)</em></li></ul><h3>Query Parameters</h3><ul><li><strong>from</strong>: <em>required (date-only)</em><p>Retrieve results starting with this date</p></li><li><strong>to</strong>: <em>required (date-only)</em><p>Retrieve results up to and including this date</p></li><li><strong>updatedFrom</strong>: <em>(date-only)</em><p>Retrieve results that have been updated from this date</p></li></ul></div><div class=\\"tab-pane\\" id=\\"plans_user__accountid__get_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>List of plans</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li><li><strong>results</strong>: <em>required (array of Plan)</em><p><strong>Items</strong>: Plan</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>endDate</strong>: <em>required (date-only)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>assignee</strong>: <em>required (assignee)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, TEAM)</em></li></ul></li><li><strong>planItem</strong>: <em>required (planItem)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of ISSUE, PROJECT)</em></li></ul></li><li><strong>recurrence</strong>: <em>required (recurrence)</em><ul><li><strong>rule</strong>: <em>required (one of NEVER, WEEKLY, BIWEEKLY, MONTHLY)</em></li><li><strong>recurrenceEndDate</strong>: <em>required (date-only)</em></li></ul></li><li><strong>dates</strong>: <em>required (dates)</em><ul><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>all</strong>: <em>required (string)</em></li></ul></li><li><strong>values</strong>: <em>required (array of PlanPeriod)</em><p><strong>Items</strong>: PlanPeriod</p><div class=\\"items\\"><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li><li><strong>timePlannedSeconds</strong>: <em>required (number)</em></li></ul></div></li></ul></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+}</code></pre></div></div><div class=\\"tab-pane\\" id=\\"plans__id__delete_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_plans_user__accountid_\\" href=\\"#panel_plans_user__accountid_\\"><span class=\\"parent\\">/plans</span>/user/{accountId}</a> <span class=\\"methods\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_plans_user__accountid_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Retrieve plans for user</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#plans_user__accountid__get_request\\" data-toggle=\\"tab\\">Request</a></li><li><a href=\\"#plans_user__accountid__get_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#plans_user__accountid__get_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"plans_user__accountid__get_request\\"><h3>URI Parameters</h3><ul><li><strong>accountId</strong>: <em>required (string)</em></li></ul><h3>Query Parameters</h3><ul><li><strong>from</strong>: <em>required (date-only)</em><p>Retrieve results starting with this date</p></li><li><strong>to</strong>: <em>required (date-only)</em><p>Retrieve results up to and including this date</p></li><li><strong>updatedFrom</strong>: <em>(date-only)</em><p>Retrieve results that have been updated from this date</p></li></ul></div><div class=\\"tab-pane\\" id=\\"plans_user__accountid__get_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>List of plans</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li><li><strong>results</strong>: <em>required (array of Plan)</em><p><strong>Items</strong>: Plan</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>endDate</strong>: <em>required (date-only)</em></li><li><strong>secondsPerDay</strong>: <em>required (number)</em></li><li><strong>includeNonWorkingDays</strong>: <em>required (boolean)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>assignee</strong>: <em>required (assignee)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, TEAM)</em></li></ul></li><li><strong>planItem</strong>: <em>required (planItem)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of ISSUE, PROJECT)</em></li></ul></li><li><strong>recurrence</strong>: <em>required (recurrence)</em><ul><li><strong>rule</strong>: <em>required (one of NEVER, WEEKLY, BIWEEKLY, MONTHLY)</em></li><li><strong>recurrenceEndDate</strong>: <em>required (date-only)</em></li></ul></li><li><strong>dates</strong>: <em>required (dates)</em><ul><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>all</strong>: <em>required (string)</em></li></ul></li><li><strong>values</strong>: <em>required (array of PlanPeriod)</em><p><strong>Items</strong>: PlanPeriod</p><div class=\\"items\\"><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li><li><strong>timePlannedSeconds</strong>: <em>required (number)</em></li></ul></div></li></ul></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
   \\"self\\": \\"https://api.tempo.io/core/3/plans/user/1111aaaa2222bbbb3333cccc?from=2017-11-01&amp;to=2017-12-31\\",
   \\"metadata\\": {
     \\"count\\": 2
@@ -1320,6 +1330,8 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
       \\"id\\": 223,
       \\"startDate\\": \\"2017-07-13\\",
       \\"endDate\\": \\"2017-11-13\\",
+      \\"secondsPerDay\\": 3600,
+      \\"includeNonWorkingDays\\": false,
       \\"description\\": \\"This is an issue plan\\",
       \\"createdAt\\": \\"2017-02-23T15:07:00Z\\",
       \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\",
@@ -1359,6 +1371,8 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
       \\"id\\": 289,
       \\"startDate\\": \\"2017-07-13\\",
       \\"endDate\\": \\"2017-11-13\\",
+      \\"secondsPerDay\\": 14400,
+      \\"includeNonWorkingDays\\": false,
       \\"description\\": \\"This is a project plan\\",
       \\"createdAt\\": \\"2017-02-23T15:07:00Z\\",
       \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\",
@@ -3048,7 +3062,224 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
     }
   ]
 }
-</code></pre></div></div><div class=\\"tab-pane\\" id=\\"work_attributes__key__get_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div><h2 class=\\"sg-h2\\" id=\\"worklogs\\">Worklogs</h2><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_worklogs\\" href=\\"#panel_worklogs\\"><span class=\\"parent\\"></span>/worklogs</a> <span class=\\"methods\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_worklogs\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Retrieve worklogs</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#worklogs_get_request\\" data-toggle=\\"tab\\">Request</a></li><li><a href=\\"#worklogs_get_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#worklogs_get_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"worklogs_get_request\\"><h3>Query Parameters</h3><ul><li><strong>issue</strong>: <em>(array of string)</em><p>Retrieve only worklogs for the given issues. Issues may be specified by either issue ids or issue keys.</p></li><li><strong>project</strong>: <em>(array of string)</em><p>Retrieve only worklogs for the given projects. Projects may be specified by either project ids or project keys.</p></li><li><strong>from</strong>: <em>(date-only)</em><p>Retrieve results starting with this date</p></li><li><strong>to</strong>: <em>(date-only)</em><p>Retrieve results up to and including this date</p></li><li><strong>updatedFrom</strong>: <em>(date-only)</em><p>Retrieve results that have been updated from this date</p></li><li><strong>offset?</strong>: <em>(integer - default: 0)</em><p>Skip over a number of elements by specifying an offset value for the query</p></li><li><strong>limit?</strong>: <em>(integer - default: 50 - maximum: 1000)</em><p>Limit the number of elements on the response</p></li></ul></div><div class=\\"tab-pane\\" id=\\"worklogs_get_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>offset</strong>: <em>required (integer - default: 0)</em></li><li><strong>limit</strong>: <em>required (integer - default: 50 - maximum: 1000)</em></li><li><strong>next</strong>: <em>(string)</em></li><li><strong>previous</strong>: <em>(string)</em></li></ul></li><li><strong>results</strong>: <em>required (array of Worklog)</em><p><strong>Items</strong>: Worklog</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>tempoWorklogId</strong>: <em>required (integer)</em></li><li><strong>jiraWorklogId</strong>: <em>(integer)</em></li><li><strong>issue</strong>: <em>required (issue)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li></ul></li><li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>startTime</strong>: <em>required (time-only)</em></li><li><strong>description</strong>: <em>required (string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>author</strong>: <em>required (author)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>attributes</strong>: <em>(attributes)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>values</strong>: <em>required (array of Work Attribute Value)</em><p><strong>Items</strong>: Work Attribute Value</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em></li><li><strong>value</strong>: <em>required (any)</em></li></ul></div></li></ul></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+</code></pre></div></div><div class=\\"tab-pane\\" id=\\"work_attributes__key__get_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div><h2 class=\\"sg-h2\\" id=\\"workload_schemes\\">Workload Schemes</h2><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_workload_schemes\\" href=\\"#panel_workload_schemes\\"><span class=\\"parent\\"></span>/workload-schemes</a> <span class=\\"methods\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_workload_schemes\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Retrieve all workload schemes</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#workload_schemes_get_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#workload_schemes_get_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"workload_schemes_get_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>List of all workload schemes</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li><li><strong>results</strong>: <em>required (array of Workload scheme)</em><p><strong>Items</strong>: Workload scheme</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>defaultScheme</strong>: <em>required (boolean)</em></li><li><strong>memberCount</strong>: <em>required (number)</em></li><li><strong>days</strong>: <em>required (array of Workload scheme day)</em><p><strong>Items</strong>: Workload scheme day</p><div class=\\"items\\"><ul><li><strong>day</strong>: <em>required (string)</em></li><li><strong>requiredSeconds</strong>: <em>required (number)</em></li></ul></div></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/workload-schemes\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/workload-schemes/123\\",
+      \\"id\\": 123,
+      \\"name\\": \\"Default Workload Scheme\\",
+      \\"description\\": \\"Employees are part of this scheme by default\\",
+      \\"defaultScheme\\": true,
+      \\"memberCount\\": 33,
+      \\"days\\": [
+        {
+          \\"day\\": \\"MONDAY\\",
+          \\"requiredSeconds\\": 28800
+        },
+        {
+          \\"day\\": \\"TUESDAY\\",
+          \\"requiredSeconds\\": 28800
+        },
+        {
+          \\"day\\": \\"WEDNESDAY\\",
+          \\"requiredSeconds\\": 28800
+        },
+        {
+          \\"day\\": \\"THURSDAY\\",
+          \\"requiredSeconds\\": 28800
+        },
+        {
+          \\"day\\": \\"FRIDAY\\",
+          \\"requiredSeconds\\": 28800
+        },
+        {
+          \\"day\\": \\"SATURDAY\\",
+          \\"requiredSeconds\\": 0
+        },
+        {
+          \\"day\\": \\"SUNDAY\\",
+          \\"requiredSeconds\\": 0
+        }
+      ]
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/workload-schemes/456\\",
+      \\"id\\": 456,
+      \\"name\\": \\"Part-time Workload Scheme\\",
+      \\"description\\": \\"Employees working 50%\\",
+      \\"defaultScheme\\": false,
+      \\"memberCount\\": 7,
+      \\"days\\": [
+        {
+          \\"day\\": \\"MONDAY\\",
+          \\"requiredSeconds\\": 14400
+        },
+        {
+          \\"day\\": \\"TUESDAY\\",
+          \\"requiredSeconds\\": 14400
+        },
+        {
+          \\"day\\": \\"WEDNESDAY\\",
+          \\"requiredSeconds\\": 14400
+        },
+        {
+          \\"day\\": \\"THURSDAY\\",
+          \\"requiredSeconds\\": 14400
+        },
+        {
+          \\"day\\": \\"FRIDAY\\",
+          \\"requiredSeconds\\": 14400
+        },
+        {
+          \\"day\\": \\"SATURDAY\\",
+          \\"requiredSeconds\\": 0
+        },
+        {
+          \\"day\\": \\"SUNDAY\\",
+          \\"requiredSeconds\\": 0
+        }
+      ]
+    }
+  ]
+}</code></pre></div><h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2><p>Client must be authenticated to access this resource.</p><h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2><p>Authenticated user is missing permission to fulfill the request</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code></pre></div></div><div class=\\"tab-pane\\" id=\\"workload_schemes_get_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_workload_schemes__id_\\" href=\\"#panel_workload_schemes__id_\\"><span class=\\"parent\\">/workload-schemes</span>/{id}</a> <span class=\\"methods\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_workload_schemes__id_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Retrieve an existing workload scheme for the given id</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#workload_schemes__id__get_request\\" data-toggle=\\"tab\\">Request</a></li><li><a href=\\"#workload_schemes__id__get_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#workload_schemes__id__get_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"workload_schemes__id__get_request\\"><h3>URI Parameters</h3><ul><li><strong>id</strong>: <em>required (string)</em></li></ul></div><div class=\\"tab-pane\\" id=\\"workload_schemes__id__get_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>Workload scheme data of the scheme that matches provided id</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>defaultScheme</strong>: <em>required (boolean)</em></li><li><strong>memberCount</strong>: <em>required (number)</em></li><li><strong>days</strong>: <em>required (array of Workload scheme day)</em><p><strong>Items</strong>: Workload scheme day</p><div class=\\"items\\"><ul><li><strong>day</strong>: <em>required (string)</em></li><li><strong>requiredSeconds</strong>: <em>required (number)</em></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/workload-schemes/123\\",
+  \\"id\\": 123,
+  \\"name\\": \\"Default Workload Scheme\\",
+  \\"description\\": \\"Employees are part of this scheme by default\\",
+  \\"defaultScheme\\": true,
+  \\"memberCount\\": 33,
+  \\"days\\": [
+    {
+      \\"day\\": \\"MONDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"TUESDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"WEDNESDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"THURSDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"FRIDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"SATURDAY\\",
+      \\"requiredSeconds\\": 0
+    },
+    {
+      \\"day\\": \\"SUNDAY\\",
+      \\"requiredSeconds\\": 0
+    }
+  ]
+}</code></pre></div><h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2><p>Client must be authenticated to access this resource.</p><h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2><p>Authenticated user is missing permission to fulfill the request</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code></pre></div><h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2><p>Workload scheme cannot be found in the system</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Workload scheme not found\\"
+    }
+  ]
+}</code></pre></div></div><div class=\\"tab-pane\\" id=\\"workload_schemes__id__get_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div><h2 class=\\"sg-h2\\" id=\\"holiday_schemes\\">Holiday Schemes</h2><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_holiday_schemes\\" href=\\"#panel_holiday_schemes\\"><span class=\\"parent\\"></span>/holiday-schemes</a> <span class=\\"methods\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_holiday_schemes\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Retrieve all holiday schemes</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#holiday_schemes_get_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#holiday_schemes_get_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"holiday_schemes_get_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>List of all holiday schemes</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li><li><strong>results</strong>: <em>required (array of Holiday scheme)</em><p><strong>Items</strong>: Holiday scheme</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>defaultScheme</strong>: <em>required (boolean)</em></li><li><strong>memberCount</strong>: <em>required (number)</em></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/holiday-schemes\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/holiday-schemes/123\\",
+      \\"id\\": 123,
+      \\"name\\": \\"Default Holiday Scheme\\",
+      \\"description\\": \\"Employees are part of this scheme by default\\",
+      \\"defaultScheme\\": true,
+      \\"memberCount\\": 33
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/holiday-schemes/456\\",
+      \\"id\\": 456,
+      \\"name\\": \\"Main Office Holiday Scheme\\",
+      \\"description\\": \\"Holiday Scheme for the main office\\",
+      \\"defaultScheme\\": false,
+      \\"memberCount\\": 7
+    }
+  ]
+}</code></pre></div><h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2><p>Client must be authenticated to access this resource.</p><h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2><p>Authenticated user is missing permission to fulfill the request</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code></pre></div></div><div class=\\"tab-pane\\" id=\\"holiday_schemes_get_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_holiday_schemes__id_\\" href=\\"#panel_holiday_schemes__id_\\"><span class=\\"parent\\">/holiday-schemes</span>/{id}</a> <span class=\\"methods\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_holiday_schemes__id_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Retrieve an existing holiday scheme</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#holiday_schemes__id__get_request\\" data-toggle=\\"tab\\">Request</a></li><li><a href=\\"#holiday_schemes__id__get_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#holiday_schemes__id__get_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"holiday_schemes__id__get_request\\"><h3>URI Parameters</h3><ul><li><strong>id</strong>: <em>required (string)</em></li></ul></div><div class=\\"tab-pane\\" id=\\"holiday_schemes__id__get_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>Holiday scheme data of the scheme that matches the provided id</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>defaultScheme</strong>: <em>required (boolean)</em></li><li><strong>memberCount</strong>: <em>required (number)</em></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/holiday-schemes/123\\",
+  \\"id\\": 123,
+  \\"name\\": \\"Default Holiday Scheme\\",
+  \\"description\\": \\"Employees are part of this scheme by default\\",
+  \\"defaultScheme\\": true,
+  \\"memberCount\\": 33
+}</code></pre></div><h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2><p>Client must be authenticated to access this resource.</p><h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2><p>Authenticated user is missing permission to fulfill the request</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code></pre></div><h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2><p>Holiday scheme cannot be found in the system</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Holiday scheme not found\\"
+    }
+  ]
+}</code></pre></div></div><div class=\\"tab-pane\\" id=\\"holiday_schemes__id__get_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_holiday_schemes__id__holidays\\" href=\\"#panel_holiday_schemes__id__holidays\\"><span class=\\"parent\\">/holiday-schemes</span>/{id}/holidays</a> <span class=\\"methods\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_holiday_schemes__id__holidays\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Retrieves holidays for an existing holiday scheme</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#holiday_schemes__id__holidays_get_request\\" data-toggle=\\"tab\\">Request</a></li><li><a href=\\"#holiday_schemes__id__holidays_get_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#holiday_schemes__id__holidays_get_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"holiday_schemes__id__holidays_get_request\\"><h3>URI Parameters</h3><ul><li><strong>id</strong>: <em>required (string)</em></li></ul><h3>Query Parameters</h3><ul><li><strong>year?</strong>: <em>required (integer)</em><p>Year for holidays to be retrieved for. Returns holidays for current year if omitted.</p></li></ul></div><div class=\\"tab-pane\\" id=\\"holiday_schemes__id__holidays_get_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>Holiday data of the scheme that matches the provided id and year</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li><li><strong>results</strong>: <em>required (array of Holiday)</em><p><strong>Items</strong>: Holiday</p><div class=\\"items\\"><ul><li><strong>name</strong>: <em>required (string)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>durationSeconds</strong>: <em>required (number)</em></li><li><strong>date</strong>: <em>required (date-only)</em></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+  \\"self\\": \\"https://test.api.tempo.io/core/3/holiday-schemes/123/holidays?year=2021\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"name\\": \\"Christmas Eve\\",
+      \\"description\\": \\"The day before Christmas\\",
+      \\"durationSeconds\\": 14400,
+      \\"date\\": \\"2021-12-24\\"
+    },
+    {
+      \\"name\\": \\"Company Day\\",
+      \\"description\\": \\"Go and have some fun\\",
+      \\"durationSeconds\\": 28800,
+      \\"date\\": \\"2021-02-24\\"
+    }
+  ]
+}</code></pre></div><h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2><p>Client must be authenticated to access this resource.</p><h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2><p>Authenticated user is missing permission to fulfill the request</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code></pre></div><h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2><p>Holiday scheme cannot be found in the system</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Holiday scheme not found\\"
+    }
+  ]
+}</code></pre></div></div><div class=\\"tab-pane\\" id=\\"holiday_schemes__id__holidays_get_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div><h2 class=\\"sg-h2\\" id=\\"worklogs\\">Worklogs</h2><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_worklogs\\" href=\\"#panel_worklogs\\"><span class=\\"parent\\"></span>/worklogs</a> <span class=\\"methods\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_worklogs\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Retrieve worklogs</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#worklogs_get_request\\" data-toggle=\\"tab\\">Request</a></li><li><a href=\\"#worklogs_get_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#worklogs_get_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"worklogs_get_request\\"><h3>Query Parameters</h3><ul><li><strong>issue</strong>: <em>(array of string)</em><p>Retrieve only worklogs for the given issues. Issues may be specified by either issue ids or issue keys.</p></li><li><strong>project</strong>: <em>(array of string)</em><p>Retrieve only worklogs for the given projects. Projects may be specified by either project ids or project keys.</p></li><li><strong>from</strong>: <em>(date-only)</em><p>Retrieve results starting with this date</p></li><li><strong>to</strong>: <em>(date-only)</em><p>Retrieve results up to and including this date</p></li><li><strong>updatedFrom</strong>: <em>(date-only)</em><p>Retrieve results that have been updated from this date</p></li><li><strong>offset?</strong>: <em>(integer - default: 0)</em><p>Skip over a number of elements by specifying an offset value for the query</p></li><li><strong>limit?</strong>: <em>(integer - default: 50 - maximum: 1000)</em><p>Limit the number of elements on the response</p></li></ul></div><div class=\\"tab-pane\\" id=\\"worklogs_get_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>offset</strong>: <em>required (integer - default: 0)</em></li><li><strong>limit</strong>: <em>required (integer - default: 50 - maximum: 1000)</em></li><li><strong>next</strong>: <em>(string)</em></li><li><strong>previous</strong>: <em>(string)</em></li></ul></li><li><strong>results</strong>: <em>required (array of Worklog)</em><p><strong>Items</strong>: Worklog</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>tempoWorklogId</strong>: <em>required (integer)</em></li><li><strong>jiraWorklogId</strong>: <em>(integer)</em></li><li><strong>issue</strong>: <em>required (issue)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li></ul></li><li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>startTime</strong>: <em>required (time-only)</em></li><li><strong>description</strong>: <em>required (string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>author</strong>: <em>required (author)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>attributes</strong>: <em>(attributes)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>values</strong>: <em>required (array of Work Attribute Value)</em><p><strong>Items</strong>: Work Attribute Value</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em></li><li><strong>value</strong>: <em>required (any)</em></li></ul></div></li></ul></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
   \\"self\\": \\"https://api.tempo.io/core/3/worklogs?from=2017-02-01&amp;to=2017-02-28&amp;offset=0&amp;limit=50\\",
   \\"metadata\\": {
     \\"count\\": 18,
@@ -3496,6 +3727,5 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
     }
   ]
 }
-</code></pre></div></div><div class=\\"tab-pane\\" id=\\"worklogs_issue__key__get_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div></div></section></article></body></html>
-"
+</code></pre></div></div><div class=\\"tab-pane\\" id=\\"worklogs_issue__key__get_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div></div></section></article></body></html>"
 `;

--- a/tests/collections/holidaySchemes.test.ts
+++ b/tests/collections/holidaySchemes.test.ts
@@ -1,0 +1,36 @@
+import HolidaySchemes from '../../src/collections/holidaySchemes';
+import MockUrlCall from './mockUrlCall';
+
+const mockUrlCall = new MockUrlCall(HolidaySchemes);
+
+describe('HolidaySchemes', () => {
+  describe('Request Functions Tests', () => {
+    it('get hits proper url', async () => {
+      const result = await mockUrlCall.call('get', []);
+      expect(result.url).toEqual(
+        'http://tempo.somehost.com:8080/core/3/holiday-schemes',
+      );
+    });
+
+    it('getHolidayScheme hits proper url', async () => {
+      const result = await mockUrlCall.call('getHolidayScheme', [
+        456,
+      ]);
+      expect(result.url).toEqual(
+        'http://tempo.somehost.com:8080/core/3/holiday-schemes/456',
+      );
+    });
+
+    it('getHolidaySchemeHolidays hits proper url', async () => {
+      const result = await mockUrlCall.call('getHolidaySchemeHolidays', [
+        456,
+        {
+          year: 2020,
+        },
+      ]);
+      expect(result.url).toEqual(
+        'http://tempo.somehost.com:8080/core/3/holiday-schemes/456/holidays?year=2020',
+      );
+    });
+  });
+});

--- a/tests/collections/workloadSchemes.test.ts
+++ b/tests/collections/workloadSchemes.test.ts
@@ -1,0 +1,24 @@
+import WorkloadSchemes from '../../src/collections/workloadSchemes';
+import MockUrlCall from './mockUrlCall';
+
+const mockUrlCall = new MockUrlCall(WorkloadSchemes);
+
+describe('WorkloadSchemes', () => {
+  describe('Request Functions Tests', () => {
+    it('get hits proper url', async () => {
+      const result = await mockUrlCall.call('get', []);
+      expect(result.url).toEqual(
+        'http://tempo.somehost.com:8080/core/3/workload-schemes',
+      );
+    });
+
+    it('get hits proper url', async () => {
+      const result = await mockUrlCall.call('getWorkloadScheme', [
+        456,
+      ]);
+      expect(result.url).toEqual(
+        'http://tempo.somehost.com:8080/core/3/workload-schemes/456',
+      );
+    });
+  });
+});

--- a/tests/tempo.test.ts
+++ b/tests/tempo.test.ts
@@ -38,6 +38,7 @@ describe('TempoApi', () => {
       expect(await tempo.accountLinks.getAccountLink('123')).toBe(dummyApiResponse);
       expect(await tempo.accounts.get()).toBe(dummyApiResponse);
       expect(await tempo.customers.get()).toBe(dummyApiResponse);
+      expect(await tempo.holidaySchemes.get()).toBe(dummyApiResponse);
       expect(await tempo.periods.get()).toBe(dummyApiResponse);
       expect(await tempo.plans.get()).toBe(dummyApiResponse);
       expect(await tempo.programs.get()).toBe(dummyApiResponse);
@@ -48,6 +49,7 @@ describe('TempoApi', () => {
       expect(await tempo.timesheetApprovals.getWaiting()).toBe(dummyApiResponse);
       expect(await tempo.userSchedule.get()).toBe(dummyApiResponse);
       expect(await tempo.workAttributes.get()).toBe(dummyApiResponse);
+      expect(await tempo.workloadSchemes.get()).toBe(dummyApiResponse);
       expect(await tempo.worklogs.get()).toBe(dummyApiResponse);
     });
   });


### PR DESCRIPTION
This should resolve #42.

Around 2-9 days ago, Tempo's REST documentation was updated. Among the changes were:

* 2 new properties added to the `Plan` response:
    * `secondsPerDay`
    * `includeNonWorkingDays`
* 2 new resources, including:
    * 3 new endpoints for `holiday-schemes`
    * 2 new endpoints for `workload-schemes`

This PR adds support for these new features.

With these changes, the tests have also been updated to test these new endpoints. (Note, the endpoints have not been functionally tested...)

