### PR TITLE
Fix types for Worklog Request Type and WorkAttributeResponse

### DIFF
--- a/src/requestTypes.ts
+++ b/src/requestTypes.ts
@@ -93,11 +93,11 @@ export interface WorklogAttribute {
 export interface Worklog {
   issueKey: string;
   timeSpentSeconds: number;
-  billableSeconds: number;
+  billableSeconds?: number; // Tempo.io documentation is unclear whether this field is required
   startDate: string;
   startTime: string;
   description?: string;
   authorAccountId: string;
-  remainingEstimateSeconds: number;
-  attributes: WorklogAttribute[];
+  remainingEstimateSeconds?: number;
+  attributes?: WorklogAttribute[];
 }

--- a/src/responseTypes.ts
+++ b/src/responseTypes.ts
@@ -170,7 +170,7 @@ export interface WorkAttributeResponse {
   name: string;
   type: string;
   required: boolean;
-  values: string[];
+  values?: string[];
 }
 
 export interface WorklogResponse {


### PR DESCRIPTION
This resolves #58 and #59.

`Worklog.attributes` has also been made optional, since tempo.io's documentation claims it's not required.