### PR TITLE
Remove david-dm.org badges on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 [![Build Status](https://github.com/leifgehrmann/node-tempo-client/workflows/Tests/badge.svg?branch=master)](https://github.com/leifgehrmann/node-tempo-client/actions)
 [![npm](https://img.shields.io/npm/v/tempo-client.svg)](https://www.npmjs.com/tempo-client)
 [![Install Size](https://packagephobia.now.sh/badge?p=tempo-client)](https://packagephobia.now.sh/result?p=tempo-client)
-[![dependency Status](https://david-dm.org/leifgehrmann/node-tempo-client/status.svg)](https://david-dm.org/leifgehrmann/node-tempo-client)
-[![devDependency Status](https://david-dm.org/leifgehrmann/node-tempo-client/dev-status.svg)](https://david-dm.org/leifgehrmann/node-tempo-client?type=dev)
 [![Code Coverage](https://codecov.io/gh/leifgehrmann/node-tempo-client/branch/master/graph/badge.svg)](https://codecov.io/gh/leifgehrmann/node-tempo-client)
 
 An unofficial node.js wrapper for the [Tempo REST API](https://tempo-io.github.io/tempo-api-docs/)


### PR DESCRIPTION
Having broken images with links to domains with expired certificates doesn't look good. So we'll just remove them.

<img width="756" alt="Screenshot 2020-11-22 at 09 34 03" src="https://user-images.githubusercontent.com/3501061/99900120-e0f04200-2ca5-11eb-8d50-aae488433c33.png">