### PR TITLE
Improve query, request, and response types

### DIFF
--- a/src/queryOptionTypes.ts
+++ b/src/queryOptionTypes.ts
@@ -23,7 +23,7 @@ export interface Issues {
 }
 
 export interface Status extends StringMap {
-  status: string;
+  status: 'OPEN' | 'CLOSED' | 'ARCHIVED';
 }
 
 export interface Id extends StringMap {

--- a/src/requestTypes.ts
+++ b/src/requestTypes.ts
@@ -1,7 +1,7 @@
 export interface Account {
   key: string;
   name: string;
-  status: string;
+  status: 'OPEN' | 'CLOSED' | 'ARCHIVED';
   leadAccountId: string;
   contactAccountId?: string;
   externalContactName?: string;
@@ -14,12 +14,12 @@ export interface Account {
 export interface AccountCategory {
   key: string;
   name: string;
-  typeName?: string;
+  typeName?: 'BILLABLE' | 'CAPITALIZED' | 'INTERNAL' | 'OPERATIONAL';
 }
 
 export interface AccountLink {
   accountKey: string;
-  scopeType: string;
+  scopeType: 'PROJECT';
   scopeId: number;
 }
 
@@ -47,7 +47,7 @@ export interface Plan {
   description?: string;
   plannedPerDaySeconds: number;
   includeNonWorkingDays?: boolean;
-  rule?: string;
+  rule?: 'NEVER' | 'WEEKLY' | 'BI_WEEKLY' | 'MONTHLY';
   recurrenceEndDate?: string;
   accountId: string;
   issueKey?: string;
@@ -66,7 +66,7 @@ export interface Role {
 
 export interface TeamLink {
   teamId: number;
-  scopeType: string;
+  scopeType: 'BOARD' | 'PROJECT';
   scopeId: string;
 }
 

--- a/src/responseTypes.ts
+++ b/src/responseTypes.ts
@@ -34,7 +34,7 @@ export interface AccountResponse {
   key: string;
   id: number;
   name: string;
-  status: string;
+  status: 'OPEN' | 'CLOSED' | 'ARCHIVED';
   global: boolean;
   monthlyBudget: number;
   lead: UserResponse;
@@ -50,7 +50,7 @@ export interface AccountLinkResponse {
   scope: {
     self: string;
     id: number;
-    type: string;
+    type: 'PROJECT';
   };
   account: SelfResponse;
 }
@@ -93,14 +93,16 @@ export interface PlanResponse {
   updatedAt: string;
   assignee: {
     self: string;
-    type: string;
+    type: 'USER' | 'TEAM';
   };
   planItem: {
     self: string;
-    type: string;
+    type: 'ISSUE' | 'PROJECT';
   };
   recurrence: {
-    rule: string;
+    // Tempo.io Documentation claims 'BIWEEKLY' does not have an underscore, unlike the request
+    // type for Plan in requestTypes.ts. If this is incorrect, report a bug.
+    rule: 'NEVER' | 'WEEKLY' | 'BIWEEKLY' | 'MONTHLY';
     recurrenceEndDate: string;
   };
   dates: {
@@ -141,7 +143,7 @@ export interface TimesheetApprovalResponse {
   requiredSeconds: number;
   timeSpentSeconds: number;
   status: {
-    key: string;
+    key: 'OPEN' | 'IN_REVIEW' | 'APPROVED';
     comment: string;
     actor: UserResponse;
     requiredSecondsAtSubmit: number;
@@ -161,7 +163,7 @@ export interface TimesheetApprovalResponse {
 export interface DayScheduleResponse {
   date: string;
   requiredSeconds: number;
-  type: string;
+  type: 'WORKING_DAY' | 'NON_WORKING_DAY' | 'HOLIDAY' | 'HOLIDAY_AND_NON_WORKING_DAY';
   holiday?: {
     name: string;
     description?: string;
@@ -170,6 +172,8 @@ export interface DayScheduleResponse {
 }
 
 export interface WorkAttributeResponse extends WorkAttribute {
+  // Tempo.io Documentation claims the `type` property will not be 'ACCOUNT'. This is probably a
+  // mistake on their part, but if it is not, please report a bug.
   self: string;
 }
 
@@ -217,7 +221,7 @@ export interface TeamLinkResponse {
   scope: {
     self: string;
     id: number;
-    type: string;
+    type: 'BOARD' | 'PROJECT';
   };
   team: {
     self: string;
@@ -232,7 +236,7 @@ export interface TeamLinkRefResponse {
   scope: {
     self: string;
     id: number;
-    type: string;
+    type: 'BOARD' | 'PROJECT';
   };
   team: SelfResponse;
 }


### PR DESCRIPTION
This PR resolves #84 by restricting the definitions of certain string types. This is technically speaking a breaking change, so this will need to be in a major version release

* `queryOptionTypes.Status.status` set to `'OPEN' | 'CLOSED' | 'ARCHIVED'`
* `requestTypes.Account.status` set to `'OPEN' | 'CLOSED' | 'ARCHIVED'`
* `requestTypes.AccountCategory.typeName` set to `'BILLABLE' | 'CAPITALIZED' | 'INTERNAL' | 'OPERATIONAL'`
* `requestTypes.AccountLint.scopeType` set to `'PROJECT'`
* `requestTypes.Plan.rule` set to `'NEVER' | 'WEEKLY' | 'BI_WEEKLY' | 'MONTHLY'`
* `requestTypes.TeamLink.scopeType` set to `'BOARD' | 'PROJECT'`
* `responseTypes.AccountResponse.status` to set `'OPEN' | 'CLOSED' | 'ARCHIVED'`
* `responseTypes.AccountLinkResponse.scope.type` set to `'PROJECT'`
* `responseTypes.AccountLinkResponse.planItem.type` set to `'ISSUE' | 'PROJECT'`
* `responseTypes.AccountLinkResponse.recurrence.rule` set to `'NEVER' | 'WEEKLY' | 'BIWEEKLY' | 'MONTHLY'`
* `responseTypes.TimesheetApprovalResponse.status.key` set to `'OPEN' | 'IN_REVIEW' | 'APPROVED'`
* `responseTypes.DayScheduleResponse.type` set to `'WORKING_DAY' | 'NON_WORKING_DAY' | 'HOLIDAY' | 'HOLIDAY_AND_NON_WORKING_DAY'`
* `responseTypes.TeamLinkResponse.scope.type` set to `'BOARD' | 'PROJECT'`
* `responseTypes.TeamLinkRefResponse.scope.type` set to `'BOARD' | 'PROJECT'`
