### PR TITLE
Added documentation diff test that formats the XML before diffing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7186,10 +7186,25 @@
       "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
       "dev": true
     },
+    "xml-formatter": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/xml-formatter/-/xml-formatter-2.4.0.tgz",
+      "integrity": "sha512-xTQ2IfbkCQKn0DGN5SD5KUgTgVohWiolyOXTLUHKJczIuSeGonN0BPduB9VQR5HOEuT1KOHQsOHSmTpU76zpUA==",
+      "dev": true,
+      "requires": {
+        "xml-parser-xo": "^3.1.1"
+      }
+    },
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
+    },
+    "xml-parser-xo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/xml-parser-xo/-/xml-parser-xo-3.1.1.tgz",
+      "integrity": "sha512-gq1nDlJxjKQpPPZUhLbJ52pghtlB4Rz6LAQULm3SF6xzOYVnUloBglNhJR9vtZB3vIxMN/R3nZTf3qmun+6GCg==",
       "dev": true
     },
     "xmlchars": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "jest": "^26.6.3",
     "ts-jest": "^26.4.4",
     "typedoc": "^0.19.2",
-    "typescript": "^4.1.2"
+    "typescript": "^4.1.2",
+    "xml-formatter": "^2.4.0"
   },
   "dependencies": {
     "axios": "^0.21.0"

--- a/tests/__snapshots__/tempoDocumentation.test.ts.snap
+++ b/tests/__snapshots__/tempoDocumentation.test.ts.snap
@@ -1,5 +1,16348 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
+"<!DOCTYPE HTML>
+<html>
+<head>
+<title>REST API documentation</title>
+<meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\">
+<meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=utf-8\\">
+<meta name=\\"generator\\" content=\\"https://github.com/raml2html/raml2html 7.5.0\\">
+<link rel=\\"stylesheet\\" href=\\"https://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css\\">
+<link rel=\\"stylesheet\\" href=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/styles/default.min.css\\">
+<script type=\\"text/javascript\\" src=\\"https://code.jquery.com/jquery-1.11.0.min.js\\"></script>
+<script type=\\"text/javascript\\" src=\\"https://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js\\"></script>
+<script type=\\"text/javascript\\" src=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/highlight.min.js\\"></script>
+<script type=\\"text/javascript\\">
+      $(document).ready(function() {
+        $('.page-header pre code, .top-resource-description pre code').each(function(i, block) {
+          hljs.highlightBlock(block);
+        });
+
+        $('[data-toggle]').click(function(e) {
+          e.preventDefault();
+          var selector = $(this).data('target') + ' pre code';
+          $(selector).each(function(i, block) {
+            hljs.highlightBlock(block);
+          });
+        });
+      });
+    </script>
+<style>
+      .hljs {
+        background: transparent;
+      }
+      .parent {
+        color: #999;
+      }
+      .list-group-item > .badge {
+        float: none;
+        margin-right: 6px;
+      }
+      .panel-heading > .methods {
+        float: right;
+      }
+      .badge {
+        border-radius: 0;
+        text-transform: uppercase;
+        width: 70px;
+        font-weight: normal;
+        color: #f3f3f6;
+        line-height: normal;
+      }
+      .badge_get {
+        background-color: #63a8e2;
+      }
+      .badge_post {
+        background-color: #6cbd7d;
+      }
+      .badge_put {
+        background-color: #22bac4;
+      }
+      .badge_delete {
+        background-color: #d26460;
+      }
+      .badge_patch {
+        background-color: #ccc444;
+      }
+      .list-group, .panel-group {
+        margin-bottom: 0;
+      }
+      .panel-group .panel+.panel-white {
+        margin-top: 0;
+      }
+      .panel-group .panel-white {
+        border-bottom: 1px solid #F5F5F5;
+        border-radius: 0;
+      }
+      .panel-white:last-child {
+        border-bottom-color: white;
+        -webkit-box-shadow: none;
+        box-shadow: none;
+      }
+      .panel-white .panel-heading {
+        background: white;
+      }
+      .tab-pane ul {
+        padding-left: 2em;
+      }
+      .tab-pane h1 {
+        font-size: 1.3em;
+      }
+      .tab-pane h2 {
+        font-size: 1.2em;
+        padding-bottom: 4px;
+        border-bottom: 1px solid #ddd;
+      }
+      .tab-pane h3 {
+        font-size: 1.1em;
+      }
+      .tab-content {
+        border-left: 1px solid #ddd;
+        border-right: 1px solid #ddd;
+        border-bottom: 1px solid #ddd;
+        padding: 10px;
+      }
+      #sidebar {
+        margin-top: 30px;
+        padding-right: 5px;
+        overflow: auto;
+        height: 90%;
+      }
+      .top-resource-description {
+        border-bottom: 1px solid #ddd;
+        background: #fcfcfc;
+        padding: 15px 15px 0 15px;
+        margin: -15px -15px 10px -15px;
+      }
+      .resource-description {
+        border-bottom: 1px solid #fcfcfc;
+        background: #fcfcfc;
+        padding: 15px 15px 0 15px;
+        margin: -15px -15px 10px -15px;
+      }
+      .resource-description p:last-child {
+        margin: 0;
+      }
+      .list-group .badge {
+        float: left;
+      }
+      .method_description {
+        margin-left: 85px;
+      }
+      .method_description p:last-child {
+        margin: 0;
+      }
+      .list-group-item {
+        /*cursor: pointer;*/
+        border: none;
+        padding: 0;
+        margin-bottom: 30px;
+      }
+      pre code {
+        overflow: auto;
+        word-wrap: normal;
+        white-space: pre;
+      }
+      .items {
+        background: #f5f5f5;
+        color: #333;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        padding: 9.5px;
+        margin: 0 0 10px;
+        font-size: 13px;
+        line-height: 1.42857143;
+      }
+      .examples {
+        margin-left: 0.5em;
+      }
+      .resource-modal li > ul {
+        margin-bottom: 1em;
+      }
+      .resource_method_title {
+        margin-bottom: 10px;
+      }
+      .sg-nav__spacer {
+        padding-top: 30px;
+      }
+    </style>
+<link href=\\"https://fonts.googleapis.com/css?family=Open+Sans:300,400,700\\" rel=\\"stylesheet\\">
+<link rel=\\"stylesheet\\" href=\\"main.css\\"></link>
+<body data-spy=\\"scroll\\" data-target=\\"#sidebar\\">
+<article class=\\"sg\\">
+<nav class=\\"sg-section sg-section--nav\\" style=\\"overflow-y: auto;\\">
+<div class=\\"sg-nav\\">
+<img class=\\"sg-nav__logo\\" src=\\"logo.png\\" alt=\\"TEMPO REST API\\" height=\\"48\\">
+<div>REST API version 3</div>
+<ul class=\\"sg-nav__links\\">
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"#accounts\\">Accounts</a>
+</li>
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"#account_categories\\">Account - Categories</a>
+</li>
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"#account_category_types\\">Account - Category - Types</a>
+</li>
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"#account_links\\">Account - Links</a>
+</li>
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"#customers\\">Customers</a>
+</li>
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"#holiday_schemes\\">Holiday Schemes</a>
+</li>
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"#periods\\">Periods</a>
+</li>
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"#permission_roles\\">Permission Roles</a>
+</li>
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"#plans\\">Plans</a>
+</li>
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"#programs\\">Programs</a>
+</li>
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"#roles\\">Roles</a>
+</li>
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"#teams\\">Teams</a>
+</li>
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"#team_links\\">Team - Links</a>
+</li>
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"#team_memberships\\">Team - Memberships</a>
+</li>
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"#timesheet_approvals\\">Timesheet Approvals</a>
+</li>
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"#user_schedule\\">User Schedule</a>
+</li>
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"#work_attributes\\">Work Attributes</a>
+</li>
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"#workload_schemes\\">Workload Schemes</a>
+</li>
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"#worklogs\\">Worklogs</a>
+</li>
+</ul>
+<div class=\\"sg-nav__spacer\\">Audit API</div>
+<ul class=\\"sg-nav__links\\">
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"https://tempo-io.github.io/tempo-audit-docs/\\">Endpoints</a>
+</li>
+</ul>
+</img>
+</div>
+<section class=\\"sg-section sg-section--main\\">
+<div class=\\"sg-content\\">
+<h1 class=\\"sg-h1\\">REST API documentation <small>version 3</small></h1>
+<p class=\\"sg-p\\">https://api.tempo.io/core/{version}</p>
+<p class=\\"sg-p\\"></p>
+<h3>About the Tempo REST API</h3>
+<p class=\\"sg-p\\">
+<strong>Version 3 of the Tempo REST API is available as of February 1st, 2019.</strong>
+</p>
+<p class=\\"sg-p\\">
+<strong>As of March 29th, 2019, version 2 has been decomissioned. Everyone using the API is encouraged to switch to version 3.</strong>
+</p>
+<p class=\\"sg-p\\">
+<strong>For more information, see <a href=\\"https://tempo-io.atlassian.net/wiki/spaces/CLOUDNEWS/pages/358810021/2018-12-07+Action+Required+for+API+Users+Jira+Cloud+Privacy+Updates\\">this announcement</a>.</strong>
+</p>
+<p class=\\"sg-p\\">The REST API is designed around a flexible and scalable architecture that will extend in lockstep with Tempo’s development.</p>
+<p class=\\"sg-p\\">We encourage you to join our developer community on Slack at <a href=\\"https://www.tempo.io/developers\\">www.tempo.io/developers</a>, where you can get support from our internal experts and share best practices with other developers building with Tempo.</p>
+<p class=\\"sg-p\\">If you have feedback or requests, you can also reach us through our <a href=\\"https://tempo-io.atlassian.net/servicedesk/customer/portal/6\\">Customer Support Portal</a>. You can find general product information in the <a href=\\"https://www.tempo.io/documentation\\">Tempo Help Center</a>.</p>
+<h3>Changes from version 2</h3>
+<h4>Privacy improvements</h4>
+<p class=\\"sg-p\\">All APIs that previously used a username to identify users now use accountId instead. Field names in JSON documents have changed accordingly, for example <code>leadUsername</code> has been replaced with <code>leadAccountId</code>.</p>
+<h4>Account contact</h4>
+<p class=\\"sg-p\\">When creating an account, separate fields are used to identify the contact depending on whether the contact is a registered Jira user.</p>
+<p class=\\"sg-p\\">The <code>contactAccountId</code> field is used to identify the contact if the contact is a registered Jira user. The <code>externalContactName</code> field is used if the contact is not a registered Jira user.</p>
+<p class=\\"sg-p\\">In account responses, a new <code>type</code> field marks the contact as a Jira user (USER) or not (EXTERNAL).</p>
+<h4>Team permission update</h4>
+<p class=\\"sg-p\\">The API for updating team permissions has been removed.</p>
+<h3>Using the REST API as an individual user</h3>
+<p class=\\"sg-p\\">You can use the REST API to interact with the data your permissions give you access to. To do so, you will need to generate a Tempo OAuth 2.0 token.</p>
+<p class=\\"sg-p\\">Go to <b>Tempo>Settings</b>, scroll down to <b>Data Access</b> and select <b>API integration</b>.</p>
+<p class=\\"sg-p\\">Once you have a token, you need to use it inside the Authorization HTTP header. Ex:<pre>curl -v -H \\"Authorization: Bearer $token\\" \\"https://api.tempo.io/core/3/worklogs?...\\"</pre></p>
+<h3>Using the REST API as an application developer</h3>
+<p class=\\"sg-p\\">If you are building apps with Tempo, and have the required Tempo administrator permissions, you can quickly obtain the OAuth 2.0 credentials you need to retrieve an access token.</p>
+<h4>Obtain your credentials</h4>
+<p class=\\"sg-p\\">Go to <b>Tempo>Settings</b>, scroll down to <b>Data Access</b> and select <b>OAuth 2.0 authentication</b>.</p>
+<p class=\\"sg-p\\">Enter a <i>Redirect URI</i> and specify the <i>Client type</i> and <i>Authorization grant type</i>. In most cases you will choose <i>Authorization code</i> as the Authorization grant type.</p>
+<p class=\\"sg-p\\">Once you click <b>Add</b>, your Client ID and Client secret are generated and you can retrieve your access token.</p>
+<h3>How to retrieve an access token for a user</h3>
+<h4>Authorization grant type used is <i>authorization_code</i></h4>
+<h5>Step 1</h5>
+<p class=\\"sg-p\\">Obtain an authorization code against your JIRA Cloud instance :<pre>GET: https://{jira-cloud-instance-name}.atlassian.net/plugins/servlet/ac/io.tempo.jira/oauth-authorize/?client_id=$CLIENT_ID&redirect_uri=$REDIRECT_URI&access_type=tenant_user</pre></p>
+<p class=\\"sg-p\\">Where <i>$CLIENT_ID</i> and <i>$REDIRECT_URI</i> match the one you generated in <b>Tempo > Settings > OAuth 2.0 Applications</b></p>
+<p class=\\"sg-p\\">You will be asked to <b>authorize</b> or <b>deny</b> access to your Tempo data. Granting access redirects you to the configured <i>redirect URI</i> with a new query string parameter named <i>code</i> (this is the authorization code). Note that this authorization code expires quickly.</p>
+<p class=\\"sg-p\\">
+<img src=\\"myapp-request-access.png\\" title=\\"MyApp Request Access\\"></img>
+<h5>Step 2</h5>
+<p class=\\"sg-p\\">Obtain an access token from Tempo by providing the <i>authorization code</i> to:<pre>POST: https://api.tempo.io/oauth/token/</pre>sending the following parameters using the \\"application/x-www-form-urlencoded\\" format:<pre>
+   grant_type = \\"authorization_code\\"
+   client_id = $CLIENT_ID
+   client_secret = $CLIENT_SECRET
+   redirect_uri = $REDIRECT_URI
+   code = $CODE
+</pre></p>
+<p class=\\"sg-p\\">The response includes the access token itself, related information, and a refresh token.<pre>
+{
+   \\"access_token\\":\\"$ACCESS_TOKEN\\",
+   \\"expires_in\\":5184000,
+   \\"token_type\\":\\"Bearer\\",
+   \\"scope\\":\\"read write\\",
+   \\"refresh_token\\":\\"$REFRESH_TOKEN\\"
+}
+</pre></p>
+<h5>Step 3</h5>
+<p class=\\"sg-p\\">Provide this <i>access token</i> to any API requests using the <i>Authorization header</i> :<pre>curl -H \\"Authorization: Bearer $ACCESS_TOKEN\\" \\"https://api.tempo.io/core/3/worklogs?from=2018-01-28&to=2018-02-03\\"</pre></p>
+<h3>How to retrieve a new access token from the refresh token</h3>
+<p class=\\"sg-p\\">The <i>access token</i> will eventually expire. You need to renew it using the previously received <i>refresh token</i>:<pre>POST: https://api.tempo.io/oauth/token/</pre>sending the following parameters using the \\"application/x-www-form-urlencoded\\" format:<pre>
+   grant_type = \\"refresh_token\\"
+   client_id = $CLIENT_ID
+   client_secret = $CLIENT_SECRET
+   redirect_uri = $REDIRECT_URI
+   refresh_token = $REFRESH_TOKEN
+</pre></p>
+<p class=\\"sg-p\\">The response will contain a new <i>access token</i> and a new <i>refresh token</i>.</p>
+<h3>How to revoke a token</h3>
+<p class=\\"sg-p\\">You can revoke an existing <i>access token</i> at any time:<pre>POST: https://api.tempo.io/oauth/revoke_token/</pre>sending the following parameters using the \\"application/x-www-form-urlencoded\\" format:<pre>
+   token_type_hint = \\"access_token\\"
+   client_id = $CLIENT_ID
+   client_secret = $CLIENT_SECRET
+   token = $ACCESS_TOKEN
+</pre></p>
+<p class=\\"sg-p\\">You can also revoke an existing <i>refresh token</i>:<pre>POST: https://api.tempo.io/oauth/revoke_token/</pre>sending the following parameters using the \\"application/x-www-form-urlencoded\\" format:<pre>
+{
+   token_type_hint = \\"refresh_token\\"
+   client_id = $CLIENT_ID
+   client_secret = $CLIENT_SECRET
+   token = $REFRESH_TOKEN
+}
+</pre></p>
+<h3>API conventions</h3>
+<h4>Identifying users</h4>
+<p class=\\"sg-p\\">The Tempo REST API uses the Atlassian accountId to identify users. The accountId is an opaque identifier that uniquely identifies the user.</p>
+<p class=\\"sg-p\\">The accountId of the current user can found using the <a href=\\"https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-group-Myself\\">Jira Myself API</a>.</p>
+<p class=\\"sg-p\\">Information about a user, given the accountId, can be retrieved using the <a href=\\"https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-group-User\\">Jira User API</a>.</p>
+<h4>Dates</h4>
+<p class=\\"sg-p\\">The API uses strings to represent dates. Dates are formatted as <a href=\\"https://en.wikipedia.org/wiki/ISO_8601#Calendar_dates\\">ISO 8601 calendar dates</a> (YYYY-MM-DD). For example, March 29th, 2019 is formatted as 2019-03-29.</p>
+<h4>Delete requests</h4>
+<p class=\\"sg-p\\">On success, delete requests return a response with status code <a href=\\"https://httpstatuses.com/204\\">204 (No content)</a>. No payload body is included in the response.</p>
+<p></p>
+<ul>
+<li><strong>version</strong>: <em>required (3)</em></li>
+</ul>
+<h2 class=\\"sg-h2\\" id=\\"accounts\\">Accounts</h2>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_accounts\\" href=\\"#panel_accounts\\"><span class=\\"parent\\"></span>/accounts</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_accounts\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Creates a new account.</p>
+<p>Separate fields are used to identify the contact depending on whether the contact is a registered Jira user or not. The <code>contactAccountId</code> field is used to identify the contact if the contact is a registered Jira user. The <code>externalContactName</code> field is used if the contact is not a registered Jira user.</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#accounts_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#accounts_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#accounts_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"accounts_post_request\\">
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>status</strong>: <em>required (one of OPEN, CLOSED, ARCHIVED)</em></li>
+<li><strong>leadAccountId</strong>: <em>required (string)</em></li>
+<li><strong>contactAccountId</strong>: <em>(string)</em><p>accountId of the contact, if the contact is a registered Jira user</p></li>
+<li><strong>externalContactName</strong>: <em>(string)</em><p>Name of the contact, if the contact is not a registered Jira user</p></li>
+<li><strong>categoryKey</strong>: <em>(string)</em></li>
+<li><strong>customerKey</strong>: <em>(string)</em></li>
+<li><strong>monthlyBudget</strong>: <em>(number)</em></li>
+<li><strong>global</strong>: <em>(boolean - default: false)</em></li>
+</ul>
+<p><strong>Examples</strong>:</p>
+<div class=\\"examples\\">
+<p><strong>Jira user as contact</strong>:<br></br><pre><code>{
+  \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
+  \\"name\\": \\"Cloudbay: Development\\",
+  \\"status\\": \\"OPEN\\",
+  \\"leadAccountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+  \\"contactAccountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+  \\"categoryKey\\": \\"dev1\\",
+  \\"customerKey\\": \\"cloudbay1\\",
+  \\"monthlyBudget\\": 600,
+  \\"global\\": false
+}</code></pre><p><strong>External contact</strong>:<br></br><pre><code>{
+  \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
+  \\"name\\": \\"Cloudbay: Development\\",
+  \\"status\\": \\"OPEN\\",
+  \\"leadAccountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+  \\"externalContactName\\": \\"John Brown\\"
+}</code></pre></p></p>
+<div class=\\"tab-pane\\" id=\\"accounts_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Account has been successfully created</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>status</strong>: <em>required (one of OPEN, CLOSED, ARCHIVED)</em></li>
+<li><strong>global</strong>: <em>required (boolean - default: false)</em></li>
+<li><strong>monthlyBudget</strong>: <em>(integer)</em></li>
+<li><strong>lead</strong>: <em>required (lead)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>contact</strong>: <em>(contact)</em><ul><li><strong>self</strong>: <em>(string)</em></li><li><strong>accountId</strong>: <em>(string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, EXTERNAL)</em><p>Indicates if the user is a registered Jira user (USER) or not (EXTERNAL)</p></li></ul></li>
+<li><strong>category</strong>: <em>(category)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (type)</em><ul><li><strong>name</strong>: <em>required (string)</em></li></ul></li></ul></li>
+<li><strong>customer</strong>: <em>(customer)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>links</strong>: <em>required (links)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_DEVELOPMENT\\",
+  \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
+  \\"id\\": 7,
+  \\"name\\": \\"Cloudbay: Development\\",
+  \\"status\\": \\"OPEN\\",
+  \\"global\\": false,
+  \\"monthlyBudget\\": 600,
+  \\"lead\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+    \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+    \\"displayName\\": \\"Erica Jefferson\\"
+  },
+  \\"contact\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+    \\"displayName\\": \\"John Brown\\",
+    \\"type\\": \\"USER\\"
+  },
+  \\"category\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/account-categories/development\\",
+    \\"key\\": \\"development\\",
+    \\"id\\": 14,
+    \\"name\\": \\"Development\\",
+    \\"type\\": {
+      \\"name\\": \\"BILLABLE\\"
+    }
+  },
+  \\"customer\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/customers/cloudbay\\",
+    \\"key\\": \\"cloudbay\\",
+    \\"id\\": 234,
+    \\"name\\": \\"CloudBay\\"
+  },
+  \\"links\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_DEVELOPMENT/links\\"
+  }
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Account cannot be created for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Account with this key already exists\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"accounts_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve existing accounts</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#accounts_get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#accounts_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#accounts_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"accounts_get_request\\">
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>status</strong>: <em>(string)</em><p>Retrieve accounts for the given status [OPEN, CLOSED, ARCHIVED]</p></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"accounts_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>List accounts</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Account)</em><p><strong>Items</strong>: Account</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>status</strong>: <em>required (one of OPEN, CLOSED, ARCHIVED)</em></li><li><strong>global</strong>: <em>required (boolean - default: false)</em></li><li><strong>monthlyBudget</strong>: <em>(integer)</em></li><li><strong>lead</strong>: <em>required (lead)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>contact</strong>: <em>(contact)</em><ul><li><strong>self</strong>: <em>(string)</em></li><li><strong>accountId</strong>: <em>(string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, EXTERNAL)</em><p>Indicates if the user is a registered Jira user (USER) or not (EXTERNAL)</p></li></ul></li><li><strong>category</strong>: <em>(category)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (type)</em><ul><li><strong>name</strong>: <em>required (string)</em></li></ul></li></ul></li><li><strong>customer</strong>: <em>(customer)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li><li><strong>links</strong>: <em>required (links)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Examples</strong>:</p>
+<div class=\\"examples\\">
+<p><strong>Retrieve all existing accounts</strong>:<br></br><pre><code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/accounts\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_DEVELOPMENT\\",
+      \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
+      \\"id\\": 7,
+      \\"name\\": \\"Cloudbay: Development\\",
+      \\"status\\": \\"OPEN\\",
+      \\"global\\": false,
+      \\"monthlyBudget\\": 600,
+      \\"lead\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+        \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+        \\"displayName\\": \\"Erica Jefferson\\"
+      },
+      \\"contact\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+        \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+        \\"displayName\\": \\"John Brown\\",
+        \\"type\\": \\"USER\\"
+      },
+      \\"category\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/account-categories/300\\",
+        \\"key\\": \\"300\\",
+        \\"id\\": 14,
+        \\"name\\": \\"Development\\",
+        \\"type\\": {
+          \\"name\\": \\"BILLABLE\\"
+        }
+      },
+      \\"customer\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/customers/100201\\",
+        \\"key\\": \\"100201\\",
+        \\"id\\": 234,
+        \\"name\\": \\"CloudBay\\"
+      },
+      \\"links\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_DEVELOPMENT/links\\"
+      }
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_CAPEX\\",
+      \\"key\\": \\"CLOUDBAY_CAPEX\\",
+      \\"id\\": 8,
+      \\"name\\": \\"Cloudbay: Capex\\",
+      \\"status\\": \\"CLOSED\\",
+      \\"global\\": false,
+      \\"lead\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+        \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+        \\"displayName\\": \\"Erica Jefferson\\"
+      },
+      \\"links\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_CAPEX/links\\"
+      }
+    }
+  ]
+}
+</code></pre><p><strong>Retrieve accounts for \\"OPEN\\" status</strong>:<br></br><pre><code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/accounts?status=OPEN\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_DEVELOPMENT\\",
+      \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
+      \\"id\\": 7,
+      \\"name\\": \\"Cloudbay: Development\\",
+      \\"status\\": \\"OPEN\\",
+      \\"global\\": false,
+      \\"monthlyBudget\\": 600,
+      \\"lead\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+        \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+        \\"displayName\\": \\"Erica Jefferson\\"
+      },
+      \\"contact\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+        \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+        \\"displayName\\": \\"John Brown\\",
+        \\"type\\": \\"USER\\"
+      },
+      \\"category\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/account-categories/300\\",
+        \\"key\\": \\"300\\",
+        \\"id\\": 14,
+        \\"name\\": \\"Development\\",
+        \\"type\\": {
+          \\"name\\": \\"BILLABLE\\"
+        }
+      },
+      \\"customer\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/customers/100201\\",
+        \\"key\\": \\"100201\\",
+        \\"id\\": 234,
+        \\"name\\": \\"CloudBay\\"
+      },
+      \\"links\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_DEVELOPMENT/links\\"
+      }
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_CAPEX\\",
+      \\"key\\": \\"CLOUDBAY_CAPEX\\",
+      \\"id\\": 8,
+      \\"name\\": \\"Cloudbay: Capex\\",
+      \\"status\\": \\"OPEN\\",
+      \\"global\\": false,
+      \\"lead\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+        \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+        \\"displayName\\": \\"Erica Jefferson\\"
+      },
+      \\"contact\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+        \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+        \\"displayName\\": \\"John Brown\\",
+        \\"type\\": \\"USER\\"
+      },
+      \\"category\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/account-categories/300\\",
+        \\"key\\": \\"300\\",
+        \\"id\\": 14,
+        \\"name\\": \\"Development\\",
+        \\"type\\": {
+          \\"name\\": \\"BILLABLE\\"
+        }
+      },
+      \\"customer\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/customers/100201\\",
+        \\"key\\": \\"100201\\",
+        \\"id\\": 234,
+        \\"name\\": \\"CloudBay\\"
+      },
+      \\"links\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_CAPEX/links\\"
+      }
+    }
+  ]
+}
+</code></pre></p><h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2><p>Client must be authenticated to access this resource.</p><h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2><p>Authenticated user is missing permission to fulfill the request</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code></pre></div></p>
+<div class=\\"tab-pane\\" id=\\"accounts_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_accounts__key_\\" href=\\"#panel_accounts__key_\\"><span class=\\"parent\\">/accounts</span>/{key}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_accounts__key_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve an existing account for the given key</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#accounts__key__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#accounts__key__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#accounts__key__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"accounts__key__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"accounts__key__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Account data of the given key</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>status</strong>: <em>required (one of OPEN, CLOSED, ARCHIVED)</em></li>
+<li><strong>global</strong>: <em>required (boolean - default: false)</em></li>
+<li><strong>monthlyBudget</strong>: <em>(integer)</em></li>
+<li><strong>lead</strong>: <em>required (lead)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>contact</strong>: <em>(contact)</em><ul><li><strong>self</strong>: <em>(string)</em></li><li><strong>accountId</strong>: <em>(string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, EXTERNAL)</em><p>Indicates if the user is a registered Jira user (USER) or not (EXTERNAL)</p></li></ul></li>
+<li><strong>category</strong>: <em>(category)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (type)</em><ul><li><strong>name</strong>: <em>required (string)</em></li></ul></li></ul></li>
+<li><strong>customer</strong>: <em>(customer)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>links</strong>: <em>required (links)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_DEVELOPMENT\\",
+  \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
+  \\"id\\": 7,
+  \\"name\\": \\"Cloudbay: Development\\",
+  \\"status\\": \\"OPEN\\",
+  \\"global\\": false,
+  \\"monthlyBudget\\": 600,
+  \\"lead\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+    \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+    \\"displayName\\": \\"Erica Jefferson\\"
+  },
+  \\"contact\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+    \\"displayName\\": \\"John Brown\\",
+    \\"type\\": \\"USER\\"
+  },
+  \\"category\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/account-categories/development\\",
+    \\"key\\": \\"development\\",
+    \\"id\\": 14,
+    \\"name\\": \\"Development\\",
+    \\"type\\": {
+      \\"name\\": \\"BILLABLE\\"
+    }
+  },
+  \\"customer\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/customers/cloudbay\\",
+    \\"key\\": \\"cloudbay\\",
+    \\"id\\": 234,
+    \\"name\\": \\"CloudBay\\"
+  },
+  \\"links\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_DEVELOPMENT/links\\"
+  }
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Account cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Account not found\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"accounts__key__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Update an existing account</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#accounts__key__put_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#accounts__key__put_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#accounts__key__put_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"accounts__key__put_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>status</strong>: <em>required (one of OPEN, CLOSED, ARCHIVED)</em></li>
+<li><strong>leadAccountId</strong>: <em>required (string)</em></li>
+<li><strong>contactAccountId</strong>: <em>(string)</em><p>accountId of the contact, if the contact is a registered Jira user</p></li>
+<li><strong>externalContactName</strong>: <em>(string)</em><p>Name of the contact, if the contact is not a registered Jira user</p></li>
+<li><strong>categoryKey</strong>: <em>(string)</em></li>
+<li><strong>customerKey</strong>: <em>(string)</em></li>
+<li><strong>monthlyBudget</strong>: <em>(number)</em></li>
+<li><strong>global</strong>: <em>(boolean - default: false)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
+  \\"name\\": \\"Cloudbay: Development\\",
+  \\"status\\": \\"OPEN\\",
+  \\"leadAccountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+  \\"contactAccountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+  \\"categoryKey\\": \\"dev1\\",
+  \\"customerKey\\": \\"cloudbay1\\",
+  \\"monthlyBudget\\": 600,
+  \\"global\\": false
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"accounts__key__put_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Account has been successfully updated</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>status</strong>: <em>required (one of OPEN, CLOSED, ARCHIVED)</em></li>
+<li><strong>global</strong>: <em>required (boolean - default: false)</em></li>
+<li><strong>monthlyBudget</strong>: <em>(integer)</em></li>
+<li><strong>lead</strong>: <em>required (lead)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>contact</strong>: <em>(contact)</em><ul><li><strong>self</strong>: <em>(string)</em></li><li><strong>accountId</strong>: <em>(string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, EXTERNAL)</em><p>Indicates if the user is a registered Jira user (USER) or not (EXTERNAL)</p></li></ul></li>
+<li><strong>category</strong>: <em>(category)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (type)</em><ul><li><strong>name</strong>: <em>required (string)</em></li></ul></li></ul></li>
+<li><strong>customer</strong>: <em>(customer)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>links</strong>: <em>required (links)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_DEVELOPMENT\\",
+  \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
+  \\"id\\": 7,
+  \\"name\\": \\"Cloudbay: Development\\",
+  \\"status\\": \\"OPEN\\",
+  \\"global\\": false,
+  \\"monthlyBudget\\": 600,
+  \\"lead\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+    \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+    \\"displayName\\": \\"Erica Jefferson\\"
+  },
+  \\"contact\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+    \\"displayName\\": \\"John Brown\\",
+    \\"type\\": \\"USER\\"
+  },
+  \\"category\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/account-categories/development\\",
+    \\"key\\": \\"development\\",
+    \\"id\\": 14,
+    \\"name\\": \\"Development\\",
+    \\"type\\": {
+      \\"name\\": \\"BILLABLE\\"
+    }
+  },
+  \\"customer\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/customers/cloudbay\\",
+    \\"key\\": \\"cloudbay\\",
+    \\"id\\": 234,
+    \\"name\\": \\"CloudBay\\"
+  },
+  \\"links\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_DEVELOPMENT/links\\"
+  }
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Account cannot be updated for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Account with this key already exists\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Account cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Account not found\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"accounts__key__put_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Delete an existing account</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#accounts__key__delete_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#accounts__key__delete_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#accounts__key__delete_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"accounts__key__delete_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"accounts__key__delete_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
+<p>Account has been successfully deleted</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Account cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Account not found\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"accounts__key__delete_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_accounts__key__links\\" href=\\"#panel_accounts__key__links\\"><span class=\\"parent\\">/accounts/{key}</span>/links</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_accounts__key__links\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"resource-description\\">
+<p>Retrieve all existing links associated to this account</p>
+</div>
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#accounts__key__links_get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#accounts__key__links_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#accounts__key__links_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"accounts__key__links_get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"accounts__key__links_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>List of all links for this account</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of AccountLink)</em><p><strong>Items</strong>: AccountLink</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (number)</em></li><li><strong>scope</strong>: <em>required (scope)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (number)</em></li><li><strong>type</strong>: <em>required (PROJECT)</em></li></ul></li><li><strong>account</strong>: <em>required (account)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_DEVELOPMENT/links\\",
+  \\"metadata\\": {
+    \\"count\\": 1
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/account-links/1\\",
+      \\"id\\": 1,
+      \\"scope\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/project/PRJ-1\\",
+        \\"id\\": 100100,
+        \\"type\\": \\"PROJECT\\"
+      },
+      \\"account\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_DEVELOPMENT\\"
+      }
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Account cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Account not found\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"accounts__key__links_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h2 class=\\"sg-h2\\" id=\\"account_categories\\">Account - Categories</h2>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_account_categories\\" href=\\"#panel_account_categories\\"><span class=\\"parent\\"></span>/account-categories</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_account_categories\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Creates a new category</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#account_categories_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#account_categories_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#account_categories_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"account_categories_post_request\\">
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>typeName</strong>: <em>(one of BILLABLE, CAPITALIZED, INTERNAL, OPERATIONAL)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
+  \\"name\\": \\"Cloudbay: Development\\",
+  \\"typeName\\": \\"BILLABLE\\"
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"account_categories_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Category has been successfully created</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>type</strong>: <em>required (type)</em><ul><li><strong>name</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/account-categories/CLOUDBAY_DEVELOPMENT\\",
+  \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
+  \\"id\\": 14,
+  \\"name\\": \\"Cloudbay: Development\\",
+  \\"type\\": {
+    \\"name\\": \\"BILLABLE\\"
+  }
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Category cannot be created for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Category with this key already exists\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"account_categories_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve all existing categories</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#account_categories_get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#account_categories_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#account_categories_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"account_categories_get_request\\">
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (integer)</em><p>Retrieve only category with this id</p></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"account_categories_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>List of all categories</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Category)</em><p><strong>Items</strong>: Category</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (type)</em><ul><li><strong>name</strong>: <em>required (string)</em></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/account-categories\\",
+  \\"metadata\\": {
+    \\"count\\": 1
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/account-categories/300\\",
+      \\"key\\": \\"300\\",
+      \\"id\\": 14,
+      \\"name\\": \\"Development\\",
+      \\"type\\": {
+        \\"name\\": \\"BILLABLE\\"
+      }
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"account_categories_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_account_categories__key_\\" href=\\"#panel_account_categories__key_\\"><span class=\\"parent\\">/account-categories</span>/{key}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_account_categories__key_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve an existing category for the given key</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#account_categories__key__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#account_categories__key__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#account_categories__key__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"account_categories__key__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"account_categories__key__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Category data of the given key</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>type</strong>: <em>required (type)</em><ul><li><strong>name</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/account-categories/CLOUDBAY_DEVELOPMENT\\",
+  \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
+  \\"id\\": 14,
+  \\"name\\": \\"Cloudbay: Development\\",
+  \\"type\\": {
+    \\"name\\": \\"BILLABLE\\"
+  }
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Category cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Invalid category key\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"account_categories__key__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Update an existing category</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#account_categories__key__put_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#account_categories__key__put_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#account_categories__key__put_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"account_categories__key__put_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>typeName</strong>: <em>(one of BILLABLE, CAPITALIZED, INTERNAL, OPERATIONAL)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
+  \\"name\\": \\"Cloudbay: Development\\",
+  \\"typeName\\": \\"BILLABLE\\"
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"account_categories__key__put_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Category has been successfully updated</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>type</strong>: <em>required (type)</em><ul><li><strong>name</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/account-categories/CLOUDBAY_DEVELOPMENT\\",
+  \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
+  \\"id\\": 14,
+  \\"name\\": \\"Cloudbay: Development\\",
+  \\"type\\": {
+    \\"name\\": \\"BILLABLE\\"
+  }
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Category cannot be updated for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Category with this key already exists\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Category cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Invalid category key\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"account_categories__key__put_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Delete an existing category</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#account_categories__key__delete_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#account_categories__key__delete_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#account_categories__key__delete_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"account_categories__key__delete_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"account_categories__key__delete_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
+<p>Category has been successfully deleted</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Category cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Invalid category key\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"account_categories__key__delete_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h2 class=\\"sg-h2\\" id=\\"account_category_types\\">Account - Category - Types</h2>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_account_category_types\\" href=\\"#panel_account_category_types\\"><span class=\\"parent\\"></span>/account-category-types</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_account_category_types\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve all existing types</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#account_category_types_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#account_category_types_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"account_category_types_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>List of all types</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of CategoryType)</em><p><strong>Items</strong>: CategoryType</p><div class=\\"items\\"><ul><li><strong>name</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/account-category-types\\",
+  \\"metadata\\": {
+    \\"count\\": 4
+  },
+  \\"results\\": [
+    {
+      \\"name\\": \\"BILLABLE\\"
+    },
+    {
+      \\"name\\": \\"CAPITALIZED\\"
+    },
+    {
+      \\"name\\": \\"INTERNAL\\"
+    },
+    {
+      \\"name\\": \\"OPERATIONAL\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"account_category_types_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h2 class=\\"sg-h2\\" id=\\"account_links\\">Account - Links</h2>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_account_links\\" href=\\"#panel_account_links\\"><span class=\\"parent\\"></span>/account-links</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_account_links\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Creates a new account-link</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#account_links_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#account_links_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#account_links_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"account_links_post_request\\">
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>accountKey</strong>: <em>required (string)</em></li>
+<li><strong>scopeType</strong>: <em>required (PROJECT)</em></li>
+<li><strong>scopeId</strong>: <em>required (number)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"accountKey\\": \\"CLOUDBAY_DEVELOPMENT\\",
+  \\"scopeType\\": \\"PROJECT\\",
+  \\"scopeId\\": 100100
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"account_links_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Account-link has been successfully-created</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (number)</em></li>
+<li><strong>scope</strong>: <em>required (scope)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (number)</em></li><li><strong>type</strong>: <em>required (PROJECT)</em></li></ul></li>
+<li><strong>account</strong>: <em>required (account)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/account-links/1\\",
+  \\"id\\": 1,
+  \\"scope\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/project/PRJ-1\\",
+    \\"id\\": 100100,
+    \\"type\\": \\"PROJECT\\"
+  },
+  \\"account\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_DEVELOPMENT\\"
+  }
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Account-link cannot be created for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Invalid account key\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"account_links_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_account_links__id_\\" href=\\"#panel_account_links__id_\\"><span class=\\"parent\\">/account-links</span>/{id}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_account_links__id_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve an existing account-link for the given id</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#account_links__id__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#account_links__id__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#account_links__id__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"account_links__id__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"account_links__id__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Retrieve a account-link</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (number)</em></li>
+<li><strong>scope</strong>: <em>required (scope)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (number)</em></li><li><strong>type</strong>: <em>required (PROJECT)</em></li></ul></li>
+<li><strong>account</strong>: <em>required (account)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/account-links/1\\",
+  \\"id\\": 1,
+  \\"scope\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/project/PRJ-1\\",
+    \\"id\\": 100100,
+    \\"type\\": \\"PROJECT\\"
+  },
+  \\"account\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_DEVELOPMENT\\"
+  }
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Account-link cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Link not found\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"account_links__id__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Delete an existing account-link</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#account_links__id__delete_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#account_links__id__delete_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#account_links__id__delete_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"account_links__id__delete_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"account_links__id__delete_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
+<p>Account-link has been successfully deleted</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Account-link cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Link not found\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"account_links__id__delete_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_account_links_project__projectkey_\\" href=\\"#panel_account_links_project__projectkey_\\"><span class=\\"parent\\">/account-links</span>/project/{projectKey}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_account_links_project__projectkey_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve account-link by project</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#account_links_project__projectkey__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#account_links_project__projectkey__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#account_links_project__projectkey__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"account_links_project__projectkey__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>projectKey</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"account_links_project__projectkey__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Retrieve account-links</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of AccountLinkByScope)</em><p><strong>Items</strong>: AccountLinkByScope</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (number)</em></li><li><strong>scope</strong>: <em>required (scope)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>account</strong>: <em>required (account)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>status</strong>: <em>required (one of OPEN, CLOSED, ARCHIVED)</em></li><li><strong>global</strong>: <em>required (boolean - default: false)</em></li><li><strong>monthlyBudget</strong>: <em>(integer)</em></li><li><strong>lead</strong>: <em>required (lead)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>contact</strong>: <em>(contact)</em><ul><li><strong>self</strong>: <em>(string)</em></li><li><strong>accountId</strong>: <em>(string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, EXTERNAL)</em><p>Indicates if the user is a registered Jira user (USER) or not (EXTERNAL)</p></li></ul></li><li><strong>category</strong>: <em>(category)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (type)</em><ul><li><strong>name</strong>: <em>required (string)</em></li></ul></li></ul></li><li><strong>customer</strong>: <em>(customer)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li><li><strong>links</strong>: <em>required (links)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/account-links/project/PROJ-1\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/account-links/1\\",
+      \\"id\\": 1,
+      \\"scope\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/project/PROJ-1\\"
+      },
+      \\"account\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_DEVELOPMENT\\",
+        \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
+        \\"id\\": 7,
+        \\"name\\": \\"Cloudbay: Development\\",
+        \\"status\\": \\"OPEN\\",
+        \\"global\\": false,
+        \\"monthlyBudget\\": 600,
+        \\"lead\\": {
+          \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+          \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+          \\"displayName\\": \\"Erica Jefferson\\"
+        },
+        \\"contact\\": {
+          \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+          \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+          \\"displayName\\": \\"John Brown\\",
+          \\"type\\": \\"USER\\"
+        },
+        \\"category\\": {
+          \\"self\\": \\"https://api.tempo.io/core/3/account-categories/300\\",
+          \\"key\\": \\"300\\",
+          \\"id\\": 14,
+          \\"name\\": \\"Development\\",
+          \\"type\\": {
+            \\"name\\": \\"BILLABLE\\"
+          }
+        },
+        \\"customer\\": {
+          \\"self\\": \\"https://api.tempo.io/core/3/customers/100201\\",
+          \\"key\\": \\"100201\\",
+          \\"id\\": 234,
+          \\"name\\": \\"CloudBay\\"
+        },
+        \\"links\\": {
+          \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_DEVELOPMENT/links\\"
+        }
+      }
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/account-links/2\\",
+      \\"id\\": 2,
+      \\"scope\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/project/PROJ-1\\"
+      },
+      \\"account\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_CAPEX\\",
+        \\"key\\": \\"CLOUDBAY_CAPEX\\",
+        \\"id\\": 8,
+        \\"name\\": \\"Cloudbay: Capex\\",
+        \\"status\\": \\"OPEN\\",
+        \\"global\\": false,
+        \\"lead\\": {
+          \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+          \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+          \\"displayName\\": \\"Erica Jefferson\\"
+        },
+        \\"links\\": {
+          \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_CAPEX/links\\"
+        }
+      }
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"account_links_project__projectkey__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h2 class=\\"sg-h2\\" id=\\"customers\\">Customers</h2>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_customers\\" href=\\"#panel_customers\\"><span class=\\"parent\\"></span>/customers</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_customers\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Creates a new customer</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#customers_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#customers_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#customers_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"customers_post_request\\">
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
+  \\"name\\": \\"Cloudbay: Development\\"
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"customers_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Customer has been successfully created</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/customers/CLOUDBAY_DEVELOPMENT\\",
+  \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
+  \\"id\\": 234,
+  \\"name\\": \\"GreenCloud\\"
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Customer cannot be created for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Customer with this key already exists\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"customers_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve all existing customers</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#customers_get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#customers_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#customers_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"customers_get_request\\">
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (integer)</em><p>Retrieve only customer with this id</p></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"customers_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>List of all customers</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Customer)</em><p><strong>Items</strong>: Customer</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/customers\\",
+  \\"metadata\\": {
+    \\"count\\": 1
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/customers/GreenCloud\\",
+      \\"key\\": \\"GreenCloud\\",
+      \\"id\\": 234,
+      \\"name\\": \\"GreenCloud\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"customers_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_customers__key_\\" href=\\"#panel_customers__key_\\"><span class=\\"parent\\">/customers</span>/{key}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_customers__key_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve an existing customer for the given key</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#customers__key__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#customers__key__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#customers__key__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"customers__key__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"customers__key__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Customer data of the given key</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/customers/CLOUDBAY_DEVELOPMENT\\",
+  \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
+  \\"id\\": 234,
+  \\"name\\": \\"GreenCloud\\"
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Customer cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Invalid customer key\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"customers__key__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Update an existing Customer</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#customers__key__put_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#customers__key__put_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#customers__key__put_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"customers__key__put_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
+  \\"name\\": \\"Cloudbay: Development\\"
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"customers__key__put_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Customer has been successfully updated</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/customers/CLOUDBAY_DEVELOPMENT\\",
+  \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
+  \\"id\\": 234,
+  \\"name\\": \\"GreenCloud\\"
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Customer cannot be updated for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Customer with this key already exists\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Customer cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Invalid customer key\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"customers__key__put_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Delete an existing customer</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#customers__key__delete_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#customers__key__delete_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#customers__key__delete_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"customers__key__delete_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"customers__key__delete_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
+<p>Customer has been successfully deleted</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Customer cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Invalid customer key\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"customers__key__delete_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_customers__key__accounts\\" href=\\"#panel_customers__key__accounts\\"><span class=\\"parent\\">/customers</span>/{key}/accounts</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_customers__key__accounts\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve all accounts for a given customer</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#customers__key__accounts_get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#customers__key__accounts_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#customers__key__accounts_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"customers__key__accounts_get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"customers__key__accounts_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>A list of accounts</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Account)</em><p><strong>Items</strong>: Account</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>status</strong>: <em>required (one of OPEN, CLOSED, ARCHIVED)</em></li><li><strong>global</strong>: <em>required (boolean - default: false)</em></li><li><strong>monthlyBudget</strong>: <em>(integer)</em></li><li><strong>lead</strong>: <em>required (lead)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>contact</strong>: <em>(contact)</em><ul><li><strong>self</strong>: <em>(string)</em></li><li><strong>accountId</strong>: <em>(string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, EXTERNAL)</em><p>Indicates if the user is a registered Jira user (USER) or not (EXTERNAL)</p></li></ul></li><li><strong>category</strong>: <em>(category)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (type)</em><ul><li><strong>name</strong>: <em>required (string)</em></li></ul></li></ul></li><li><strong>customer</strong>: <em>(customer)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li><li><strong>links</strong>: <em>required (links)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/customers/CLOUDBAY/accounts\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_DEVELOPMENT\\",
+      \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
+      \\"id\\": 7,
+      \\"name\\": \\"Cloudbay: Development\\",
+      \\"status\\": \\"OPEN\\",
+      \\"global\\": false,
+      \\"monthlyBudget\\": 600,
+      \\"lead\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+        \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+        \\"displayName\\": \\"Erica Jefferson\\"
+      },
+      \\"contact\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+        \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+        \\"displayName\\": \\"John Brown\\",
+        \\"type\\": \\"USER\\"
+      },
+      \\"category\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/account-categories/300\\",
+        \\"key\\": \\"300\\",
+        \\"id\\": 14,
+        \\"name\\": \\"Development\\",
+        \\"type\\": {
+          \\"name\\": \\"BILLABLE\\"
+        }
+      },
+      \\"customer\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/customers/CLOUDBAY\\",
+        \\"key\\": \\"CLOUDBAY\\",
+        \\"id\\": 234,
+        \\"name\\": \\"CloudBay\\"
+      },
+      \\"links\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_DEVELOPMENT/links\\"
+      }
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_CAPEX\\",
+      \\"key\\": \\"CLOUDBAY_CAPEX\\",
+      \\"id\\": 8,
+      \\"name\\": \\"Cloudbay: Capex\\",
+      \\"status\\": \\"ARCHIVED\\",
+      \\"global\\": true,
+      \\"lead\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+        \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+        \\"displayName\\": \\"Erica Jefferson\\"
+      },
+      \\"customer\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/customers/CLOUDBAY\\",
+        \\"key\\": \\"CLOUDBAY\\",
+        \\"id\\": 234,
+        \\"name\\": \\"CloudBay\\"
+      },
+      \\"links\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/accounts/CLOUDBAY_CAPEX/links\\"
+      }
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Customer cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Invalid customer key\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"customers__key__accounts_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h2 class=\\"sg-h2\\" id=\\"holiday_schemes\\">Holiday Schemes</h2>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_holiday_schemes\\" href=\\"#panel_holiday_schemes\\"><span class=\\"parent\\"></span>/holiday-schemes</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_holiday_schemes\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve all holiday schemes</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#holiday_schemes_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"holiday_schemes_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>List of all holiday schemes</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>offset</strong>: <em>required (integer - default: 0)</em></li><li><strong>limit</strong>: <em>required (integer - default: 50 - maximum: 1000)</em></li><li><strong>next</strong>: <em>(string)</em></li><li><strong>previous</strong>: <em>(string)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of User)</em><p><strong>Items</strong>: User</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/holiday-schemes\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/holiday-schemes/123\\",
+      \\"id\\": 123,
+      \\"name\\": \\"Default Holiday Scheme\\",
+      \\"description\\": \\"Employees are part of this scheme by default\\",
+      \\"defaultScheme\\": true,
+      \\"memberCount\\": 33
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/holiday-schemes/456\\",
+      \\"id\\": 456,
+      \\"name\\": \\"Main Office Holiday Scheme\\",
+      \\"description\\": \\"Holiday Scheme for the main office\\",
+      \\"defaultScheme\\": false,
+      \\"memberCount\\": 7
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Create a Holiday scheme</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#holiday_schemes_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"holiday_schemes_post_request\\">
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Holiday scheme data of the scheme that was created</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>defaultScheme</strong>: <em>required (boolean)</em></li>
+<li><strong>memberCount</strong>: <em>required (number)</em></li>
+</ul>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Holiday scheme cannot be created for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"You must specify a scheme name\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_holiday_schemes__id_\\" href=\\"#panel_holiday_schemes__id_\\"><span class=\\"parent\\">/holiday-schemes</span>/{id}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_holiday_schemes__id_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve an existing holiday scheme</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#holiday_schemes__id__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"holiday_schemes__id__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Holiday scheme data of the scheme that matches the provided id</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>defaultScheme</strong>: <em>required (boolean)</em></li>
+<li><strong>memberCount</strong>: <em>required (number)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/holiday-schemes/123\\",
+  \\"id\\": 123,
+  \\"name\\": \\"Default Holiday Scheme\\",
+  \\"description\\": \\"Employees are part of this scheme by default\\",
+  \\"defaultScheme\\": true,
+  \\"memberCount\\": 33
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Holiday scheme cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Holiday scheme not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Update a holiday scheme</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#holiday_schemes__id__put_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__put_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__put_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"holiday_schemes__id__put_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__put_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Holiday scheme has been successfully updated</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>defaultScheme</strong>: <em>required (boolean)</em></li>
+<li><strong>memberCount</strong>: <em>required (number)</em></li>
+</ul>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Holiday scheme cannot be updated for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"You must specify a scheme name\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Holiday scheme cannot be found in the system</p>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__put_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Delete a holiday scheme</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#holiday_schemes__id__delete_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__delete_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__delete_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"holiday_schemes__id__delete_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__delete_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
+<p>Holiday scheme been successfully deleted</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Holiday scheme cannot be found in the system</p>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__delete_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_holiday_schemes__id__default\\" href=\\"#panel_holiday_schemes__id__default\\"><span class=\\"parent\\">/holiday-schemes/{id}</span>/default</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_holiday_schemes__id__default\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Set the default holiday scheme</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#holiday_schemes__id__default_put_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__default_put_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__default_put_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"holiday_schemes__id__default_put_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__default_put_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>The Holiday scheme has been successfully set as default</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>defaultScheme</strong>: <em>required (boolean)</em></li>
+<li><strong>memberCount</strong>: <em>required (number)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/holiday-schemes/123\\",
+  \\"id\\": 123,
+  \\"name\\": \\"Default Holiday Scheme\\",
+  \\"description\\": \\"Employees are part of this scheme by default\\",
+  \\"defaultScheme\\": true,
+  \\"memberCount\\": 33
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Holiday scheme cannot be found in the system</p>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__default_put_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_holiday_schemes__id__holidays\\" href=\\"#panel_holiday_schemes__id__holidays\\"><span class=\\"parent\\">/holiday-schemes/{id}</span>/holidays</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_holiday_schemes__id__holidays\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve holidays for an existing holiday scheme</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#holiday_schemes__id__holidays_get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__holidays_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__holidays_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"holiday_schemes__id__holidays_get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>year</strong>: <em>(integer)</em><p>Year for holidays to be retrieved for. Returns holidays for current year if omitted.</p></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__holidays_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Holiday data of the scheme that matches the provided id and year</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Holiday)</em><p><strong>Items</strong>: Holiday</p><div class=\\"items\\"><ul><li><strong>name</strong>: <em>required (string)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>durationSeconds</strong>: <em>required (number)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://test.api.tempo.io/core/3/holiday-schemes/123/holidays?year=2021\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://test.api.tempo.io/core/3/holidays/1\\",
+      \\"id\\": 1,
+      \\"schemeId\\": 1,
+      \\"type\\": \\"FIXED\\",
+      \\"name\\": \\"Company Day\\",
+      \\"description\\": \\"Go and have some fun\\",
+      \\"durationSeconds\\": 28800,
+      \\"date\\": \\"2021-02-24\\"
+    },
+    {
+      \\"self\\": \\"https://test.api.tempo.io/core/3/holidays/2\\",
+      \\"id\\": 2,
+      \\"schemeId\\": 1,
+      \\"type\\": \\"FLOATING\\",
+      \\"name\\": \\"Christmas Eve\\",
+      \\"description\\": \\"The day before Christmas\\",
+      \\"durationSeconds\\": 14400,
+      \\"date\\": \\"2021-12-24\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Holiday scheme cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Holiday scheme not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__holidays_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Create a Holiday</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#holiday_schemes__id__holidays_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__holidays_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__holidays_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"holiday_schemes__id__holidays_post_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>type</strong>: <em>required (one of FIXED, FLOATING)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>durationSeconds</strong>: <em>required (number)</em></li>
+<li><strong>date</strong>: <em>required (date-only)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"type\\": \\"FIXED\\",
+  \\"name\\": \\"Christmas Eve\\",
+  \\"description\\": \\"The day before Christmas\\",
+  \\"durationSeconds\\": 14400,
+  \\"date\\": \\"2021-12-24\\"
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__holidays_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Holiday data that was created</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (number)</em></li>
+<li><strong>schemeId</strong>: <em>required (number)</em></li>
+<li><strong>type</strong>: <em>required (one of FIXED, FLOATING)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>durationSeconds</strong>: <em>required (number)</em></li>
+<li><strong>date</strong>: <em>required (date-only)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://test.api.tempo.io/core/3/holidays/1\\",
+  \\"id\\": 1,
+  \\"schemeId\\": 1,
+  \\"type\\": \\"FIXED\\",
+  \\"name\\": \\"Christmas Eve\\",
+  \\"description\\": \\"The day before Christmas\\",
+  \\"durationSeconds\\": 14400,
+  \\"date\\": \\"2021-12-24\\"
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Holiday cannot be created for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"You must specify a holiday name\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__holidays_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_holiday_schemes__id__holidays__id_\\" href=\\"#panel_holiday_schemes__id__holidays__id_\\"><span class=\\"parent\\">/holiday-schemes/{id}/holidays</span>/{id}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_holiday_schemes__id__holidays__id_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve an existing holiday</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#holiday_schemes__id__holidays__id__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__holidays__id__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__holidays__id__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"holiday_schemes__id__holidays__id__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__holidays__id__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Holiday data that matches the provided id</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (number)</em></li>
+<li><strong>schemeId</strong>: <em>required (number)</em></li>
+<li><strong>type</strong>: <em>required (one of FIXED, FLOATING)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>durationSeconds</strong>: <em>required (number)</em></li>
+<li><strong>date</strong>: <em>required (date-only)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>Can not resolve examples/holiday  -scheme-holiday.json</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Holiday cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Holiday not found\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__holidays__id__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Update a holiday</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#holiday_schemes__id__holidays__id__put_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__holidays__id__put_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__holidays__id__put_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"holiday_schemes__id__holidays__id__put_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>type</strong>: <em>required (one of FIXED, FLOATING)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>durationSeconds</strong>: <em>required (number)</em></li>
+<li><strong>date</strong>: <em>required (date-only)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__holidays__id__put_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Holiday has been successfully updated</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (number)</em></li>
+<li><strong>schemeId</strong>: <em>required (number)</em></li>
+<li><strong>type</strong>: <em>required (one of FIXED, FLOATING)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>durationSeconds</strong>: <em>required (number)</em></li>
+<li><strong>date</strong>: <em>required (date-only)</em></li>
+</ul>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Holiday cannot be updated for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"You must specify a holiday name\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Holiday cannot be found in the system</p>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__holidays__id__put_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Delete a holiday</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#holiday_schemes__id__holidays__id__delete_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__holidays__id__delete_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__holidays__id__delete_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"holiday_schemes__id__holidays__id__delete_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__holidays__id__delete_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
+<p>Holiday been successfully deleted</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Holiday cannot be found in the system</p>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__holidays__id__delete_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_holiday_schemes__id__members\\" href=\\"#panel_holiday_schemes__id__members\\"><span class=\\"parent\\">/holiday-schemes/{id}</span>/members</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_holiday_schemes__id__members\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Get members in a holiday scheme</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#holiday_schemes__id__members_get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__members_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__members_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"holiday_schemes__id__members_get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__members_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Members in the holiday scheme</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Holiday scheme)</em><p><strong>Items</strong>: Holiday scheme</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>defaultScheme</strong>: <em>required (boolean)</em></li><li><strong>memberCount</strong>: <em>required (number)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/holiday-schemes/1/members&amp;offset=0&amp;limit=50\\",
+  \\"metadata\\": {
+    \\"count\\": 18,
+    \\"offset\\": 0,
+    \\"limit\\": 50
+  },
+  \\"results\\": [
+    // skipped
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Holiday scheme cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Holiday scheme not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__members_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Assign a holiday scheme to members</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#holiday_schemes__id__members_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__members_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes__id__members_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"holiday_schemes__id__members_post_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>accountIds</strong>: <em>required (array of )</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__members_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
+<p>Users have been successfully added to the holiday scheme</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Holiday scheme membershop cannot be updated for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"User is invalid\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Holiday scheme cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Holiday scheme not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes__id__members_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_holiday_schemes_users__accountid_\\" href=\\"#panel_holiday_schemes_users__accountid_\\"><span class=\\"parent\\">/holiday-schemes</span>/users/{accountId}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_holiday_schemes_users__accountid_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Get user scheme</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#holiday_schemes_users__accountid__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes_users__accountid__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#holiday_schemes_users__accountid__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"holiday_schemes_users__accountid__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>accountId</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes_users__accountid__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>The user holiday scheme</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>defaultScheme</strong>: <em>required (boolean)</em></li>
+<li><strong>memberCount</strong>: <em>required (number)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/holiday-schemes/123\\",
+  \\"id\\": 123,
+  \\"name\\": \\"Default Holiday Scheme\\",
+  \\"description\\": \\"Employees are part of this scheme by default\\",
+  \\"defaultScheme\\": true,
+  \\"memberCount\\": 33
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"holiday_schemes_users__accountid__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h2 class=\\"sg-h2\\" id=\\"periods\\">Periods</h2>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_periods\\" href=\\"#panel_periods\\"><span class=\\"parent\\"></span>/periods</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_periods\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve all periods for a given date range</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#periods_get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#periods_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#periods_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"periods_get_request\\">
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>from</strong>: <em>required (date-only)</em><p>Retrieve results starting with this date</p></li>
+<li><strong>to</strong>: <em>required (date-only)</em><p>Retrieve results up to and including this date</p></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"periods_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>periods</strong>: <em>required (array of Period)</em><p><strong>Items</strong>: Period</p><div class=\\"items\\"><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"periods\\": [
+    {
+      \\"from\\": \\"2017-12-01\\",
+      \\"to\\": \\"2017-12-31\\"
+    },
+    {
+      \\"from\\": \\"2018-01-01\\",
+      \\"to\\": \\"2018-01-31\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+</div>
+<div class=\\"tab-pane\\" id=\\"periods_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h2 class=\\"sg-h2\\" id=\\"permission_roles\\">Permission Roles</h2>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_permission_roles\\" href=\\"#panel_permission_roles\\"><span class=\\"parent\\"></span>/permission-roles</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_permission_roles\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve permission roles</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#permission_roles_get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#permission_roles_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#permission_roles_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"permission_roles_get_request\\">
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>teamId</strong>: <em>(integer)</em><p>Retrieve permission roles for a single team</p></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"permission_roles_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>List of permission roles</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Permission role)</em><p><strong>Items</strong>: Permission role</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>permissions</strong>: <em>required (array of Permission role permission)</em><p><strong>Items</strong>: Permission role permission</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em><p>Permission key.</p></li></ul></div></li><li><strong>permittedUsers</strong>: <em>required (array of User)</em><p><strong>Items</strong>: User</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></div></li><li><strong>accessType</strong>: <em>required (one of TEAM, GLOBAL)</em><p>GLOBAL permission roles don&#39;t have entities.</p></li><li><strong>accessEntities</strong>: <em>required (array of Permission role entity)</em><p><strong>Items</strong>: Permission role entity</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (number)</em><p>Id of the linked entity, for example teamId for access type TEAM.</p></li></ul></div></li><li><strong>editable</strong>: <em>required (boolean)</em><p>Editable roles are manually created with updatable members.</p></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://test.api.tempo.io/core/3/permission-roles\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://test.api.tempo.io/core/3/permission-roles/6\\",
+      \\"id\\": 6,
+      \\"name\\": \\"Team Role\\",
+      \\"permissions\\": [
+        {
+          \\"key\\": \\"permissions.worklog.view\\"
+        }
+      ],
+      \\"permittedUsers\\": [
+        {
+          \\"self\\": \\"https://test.atlassian.net/rest/api/2/user?accountId=jira-account-id\\",
+          \\"accountId\\": \\"jira-account-id-adm1n\\",
+          \\"displayName\\": \\"John Brown\\"
+        }
+      ],
+      \\"accessType\\": \\"TEAM\\",
+      \\"accessEntities\\": [
+        {
+          \\"id\\": 1,
+          \\"self\\": \\"https://test.api.tempo.io/core/3/teams/1\\"
+        }
+      ],
+      \\"editable\\": true
+    },
+    {
+      \\"self\\": \\"https://test.api.tempo.io/core/3/permission-roles/7\\",
+      \\"id\\": 7,
+      \\"name\\": \\"Global Role\\",
+      \\"permissions\\": [
+        {
+          \\"key\\": \\"permissions.worklog.manage\\"
+        }
+      ],
+      \\"permittedUsers\\": [
+        {
+          \\"self\\": \\"https://test.atlassian.net/rest/api/2/user?accountId=jira-account-id\\",
+          \\"accountId\\": \\"jira-account-id-adm1n\\",
+          \\"displayName\\": \\"John Brown\\"
+        }
+      ],
+      \\"accessType\\": \\"GLOBAL\\",
+      \\"accessEntities\\": [
+      ],
+      \\"editable\\": true
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"permission_roles_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Create a new editable permission role</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#permission_roles_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#permission_roles_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#permission_roles_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"permission_roles_post_request\\">
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>permissionsKeys</strong>: <em>required (array of )</em></li>
+<li><strong>permittedAccountIds</strong>: <em>required (array of )</em></li>
+<li><strong>accessType</strong>: <em>required (one of TEAM, GLOBAL)</em><p>GLOBAL permission roles don&#39;t have entities.</p></li>
+<li><strong>accessEntityIds</strong>: <em>required (array of )</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"name\\": \\"The Role\\",
+  \\"permissionKeys\\": [
+    \\"permissions.worklog.view\\"
+  ],
+  \\"permittedAccountIds\\": [
+    \\"jira-account-id\\"
+  ],
+  \\"accessType\\": \\"TEAM\\",
+  \\"accessEntityIds\\" : [
+    1
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"permission_roles_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Permission role has been successfully created</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>permissions</strong>: <em>required (array of Permission role permission)</em><p><strong>Items</strong>: Permission role permission</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em><p>Permission key.</p></li></ul></div></li>
+<li><strong>permittedUsers</strong>: <em>required (array of User)</em><p><strong>Items</strong>: User</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></div></li>
+<li><strong>accessType</strong>: <em>required (one of TEAM, GLOBAL)</em><p>GLOBAL permission roles don&#39;t have entities.</p></li>
+<li><strong>accessEntities</strong>: <em>required (array of Permission role entity)</em><p><strong>Items</strong>: Permission role entity</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (number)</em><p>Id of the linked entity, for example teamId for access type TEAM.</p></li></ul></div></li>
+<li><strong>editable</strong>: <em>required (boolean)</em><p>Editable roles are manually created with updatable members.</p></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://test.api.tempo.io/core/3/permission-roles/6\\",
+  \\"id\\": 6,
+  \\"name\\": \\"The Role\\",
+  \\"permissions\\": [
+    {
+      \\"key\\": \\"permissions.worklog.view\\"
+    }
+  ],
+  \\"permittedUsers\\": [
+    {
+      \\"self\\": \\"https://test.atlassian.net/rest/api/2/user?accountId=jira-account-id\\",
+      \\"accountId\\": \\"jira-account-id\\",
+      \\"displayName\\": \\"John Brown\\"
+    }
+  ],
+  \\"accessType\\": \\"TEAM\\",
+  \\"accessEntities\\": [
+    {
+      \\"id\\": 1,
+      \\"self\\": \\"https://test.api.tempo.io/core/3/teams/1\\"
+    }
+  ],
+  \\"editable\\": true
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"permission_roles_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_permission_roles_global\\" href=\\"#panel_permission_roles_global\\"><span class=\\"parent\\">/permission-roles</span>/global</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_permission_roles_global\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve global permission roles</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#permission_roles_global_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#permission_roles_global_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"permission_roles_global_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>List of global permission roles</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Permission role)</em><p><strong>Items</strong>: Permission role</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>permissions</strong>: <em>required (array of Permission role permission)</em><p><strong>Items</strong>: Permission role permission</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em><p>Permission key.</p></li></ul></div></li><li><strong>permittedUsers</strong>: <em>required (array of User)</em><p><strong>Items</strong>: User</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></div></li><li><strong>accessType</strong>: <em>required (one of TEAM, GLOBAL)</em><p>GLOBAL permission roles don&#39;t have entities.</p></li><li><strong>accessEntities</strong>: <em>required (array of Permission role entity)</em><p><strong>Items</strong>: Permission role entity</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (number)</em><p>Id of the linked entity, for example teamId for access type TEAM.</p></li></ul></div></li><li><strong>editable</strong>: <em>required (boolean)</em><p>Editable roles are manually created with updatable members.</p></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://test.api.tempo.io/core/3/permission-roles\\",
+  \\"metadata\\": {
+    \\"count\\": 1
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://test.api.tempo.io/core/3/permission-roles/7\\",
+      \\"id\\": 7,
+      \\"name\\": \\"Global Role\\",
+      \\"permissions\\": [
+        {
+          \\"key\\": \\"permissions.worklog.manage\\"
+        }
+      ],
+      \\"permittedUsers\\": [
+        {
+          \\"self\\": \\"https://test.atlassian.net/rest/api/2/user?accountId=jira-account-id\\",
+          \\"accountId\\": \\"jira-account-id-adm1n\\",
+          \\"displayName\\": \\"John Brown\\"
+        }
+      ],
+      \\"accessType\\": \\"GLOBAL\\",
+      \\"accessEntities\\": [
+      ],
+      \\"editable\\": true
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"permission_roles_global_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_permission_roles__id_\\" href=\\"#panel_permission_roles__id_\\"><span class=\\"parent\\">/permission-roles</span>/{id}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_permission_roles__id_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve a permission role</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#permission_roles__id__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#permission_roles__id__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#permission_roles__id__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"permission_roles__id__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"permission_roles__id__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>A permission role</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>permissions</strong>: <em>required (array of Permission role permission)</em><p><strong>Items</strong>: Permission role permission</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em><p>Permission key.</p></li></ul></div></li>
+<li><strong>permittedUsers</strong>: <em>required (array of User)</em><p><strong>Items</strong>: User</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></div></li>
+<li><strong>accessType</strong>: <em>required (one of TEAM, GLOBAL)</em><p>GLOBAL permission roles don&#39;t have entities.</p></li>
+<li><strong>accessEntities</strong>: <em>required (array of Permission role entity)</em><p><strong>Items</strong>: Permission role entity</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (number)</em><p>Id of the linked entity, for example teamId for access type TEAM.</p></li></ul></div></li>
+<li><strong>editable</strong>: <em>required (boolean)</em><p>Editable roles are manually created with updatable members.</p></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://test.api.tempo.io/core/3/permission-roles/6\\",
+  \\"id\\": 6,
+  \\"name\\": \\"The Role\\",
+  \\"permissions\\": [
+    {
+      \\"key\\": \\"permissions.worklog.view\\"
+    }
+  ],
+  \\"permittedUsers\\": [
+    {
+      \\"self\\": \\"https://test.atlassian.net/rest/api/2/user?accountId=jira-account-id\\",
+      \\"accountId\\": \\"jira-account-id\\",
+      \\"displayName\\": \\"John Brown\\"
+    }
+  ],
+  \\"accessType\\": \\"TEAM\\",
+  \\"accessEntities\\": [
+    {
+      \\"id\\": 1,
+      \\"self\\": \\"https://test.api.tempo.io/core/3/teams/1\\"
+    }
+  ],
+  \\"editable\\": true
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Permission role cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Permission role not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"permission_roles__id__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Update a permission role. Only members of editable roles can be updated.</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#permission_roles__id__put_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#permission_roles__id__put_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#permission_roles__id__put_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"permission_roles__id__put_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>permissionsKeys</strong>: <em>required (array of )</em></li>
+<li><strong>permittedAccountIds</strong>: <em>required (array of )</em></li>
+<li><strong>accessType</strong>: <em>required (one of TEAM, GLOBAL)</em><p>GLOBAL permission roles don&#39;t have entities.</p></li>
+<li><strong>accessEntityIds</strong>: <em>required (array of )</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"name\\": \\"The Role\\",
+  \\"permissionKeys\\": [
+    \\"permissions.worklog.view\\"
+  ],
+  \\"permittedAccountIds\\": [
+    \\"jira-account-id\\"
+  ],
+  \\"accessType\\": \\"TEAM\\",
+  \\"accessEntityIds\\" : [
+    1
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"permission_roles__id__put_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Permission role has been successfully updated</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>permissions</strong>: <em>required (array of Permission role permission)</em><p><strong>Items</strong>: Permission role permission</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em><p>Permission key.</p></li></ul></div></li>
+<li><strong>permittedUsers</strong>: <em>required (array of User)</em><p><strong>Items</strong>: User</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></div></li>
+<li><strong>accessType</strong>: <em>required (one of TEAM, GLOBAL)</em><p>GLOBAL permission roles don&#39;t have entities.</p></li>
+<li><strong>accessEntities</strong>: <em>required (array of Permission role entity)</em><p><strong>Items</strong>: Permission role entity</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (number)</em><p>Id of the linked entity, for example teamId for access type TEAM.</p></li></ul></div></li>
+<li><strong>editable</strong>: <em>required (boolean)</em><p>Editable roles are manually created with updatable members.</p></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"name\\": \\"The Role\\",
+  \\"permissionKeys\\": [
+    \\"permissions.worklog.view\\"
+  ],
+  \\"permittedAccountIds\\": [
+    \\"jira-account-id\\"
+  ],
+  \\"accessType\\": \\"TEAM\\",
+  \\"accessEntityIds\\" : [
+    1
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Permission role cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Permission role not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"permission_roles__id__put_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Delete an editable permission role</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#permission_roles__id__delete_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#permission_roles__id__delete_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#permission_roles__id__delete_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"permission_roles__id__delete_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"permission_roles__id__delete_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
+<p>Permission role has been successfully deleted</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Permission role cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Permission role not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"permission_roles__id__delete_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h2 class=\\"sg-h2\\" id=\\"plans\\">Plans</h2>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_plans\\" href=\\"#panel_plans\\"><span class=\\"parent\\"></span>/plans</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_plans\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve plans</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#plans_get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#plans_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#plans_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"plans_get_request\\">
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>assigneeType</strong>: <em>(string)</em><p>Retrieve only plans with assignees of the given type.</p></li>
+<li><strong>planItemType</strong>: <em>(string)</em><p>Retrieve only plans with plan items of the given type.</p></li>
+<li><strong>from</strong>: <em>required (date-only)</em><p>Retrieve results starting with this date</p></li>
+<li><strong>to</strong>: <em>required (date-only)</em><p>Retrieve results up to and including this date</p></li>
+<li><strong>updatedFrom</strong>: <em>(date-only)</em><p>Retrieve results that have been updated from this date</p></li>
+<li><strong>offset?</strong>: <em>(integer - default: 0)</em><p>Skip over a number of elements by specifying an offset value for the query</p></li>
+<li><strong>limit?</strong>: <em>(integer - default: 50 - maximum: 1000)</em><p>Limit the number of elements on the response</p></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"plans_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>offset</strong>: <em>required (integer - default: 0)</em></li><li><strong>limit</strong>: <em>required (integer - default: 50 - maximum: 1000)</em></li><li><strong>next</strong>: <em>(string)</em></li><li><strong>previous</strong>: <em>(string)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Plan)</em><p><strong>Items</strong>: Plan</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>endDate</strong>: <em>required (date-only)</em></li><li><strong>secondsPerDay</strong>: <em>required (number)</em></li><li><strong>includeNonWorkingDays</strong>: <em>required (boolean)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>assignee</strong>: <em>required (assignee)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, TEAM)</em></li></ul></li><li><strong>planItem</strong>: <em>required (planItem)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of ISSUE, PROJECT)</em></li></ul></li><li><strong>recurrence</strong>: <em>required (recurrence)</em><ul><li><strong>rule</strong>: <em>required (one of NEVER, WEEKLY, BIWEEKLY, MONTHLY)</em></li><li><strong>recurrenceEndDate</strong>: <em>required (date-only)</em></li></ul></li><li><strong>dates</strong>: <em>required (dates)</em><ul><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>all</strong>: <em>required (string)</em></li></ul></li><li><strong>values</strong>: <em>required (array of PlanPeriod)</em><p><strong>Items</strong>: PlanPeriod</p><div class=\\"items\\"><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li><li><strong>timePlannedSeconds</strong>: <em>required (number)</em></li></ul></div></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/plans?assigneeType=USER&amp;planItemType=ISSUE&amp;from=2017-11-01&amp;to=2017-12-31&amp;updatedFrom=2017-02-01&amp;offset=0&amp;limit=50\\",
+  \\"metadata\\": {
+    \\"count\\": 2,
+    \\"offset\\": 0,
+    \\"limit\\": 50
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/plans/223\\",
+      \\"id\\": 223,
+      \\"startDate\\": \\"2017-07-13\\",
+      \\"endDate\\": \\"2017-11-13\\",
+      \\"secondsPerDay\\": 3600,
+      \\"includeNonWorkingDays\\": false,
+      \\"description\\": \\"This is an issue plan\\",
+      \\"createdAt\\": \\"2017-02-23T15:07:00Z\\",
+      \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\",
+      \\"assignee\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+        \\"type\\": \\"USER\\"
+      },
+      \\"planItem\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/issue/ISS-555\\",
+        \\"type\\": \\"ISSUE\\"
+      },
+      \\"recurrence\\": {
+        \\"rule\\": \\"MONTHLY\\",
+        \\"recurrenceEndDate\\": \\"2018-12-31\\"
+      },
+      \\"dates\\": {
+        \\"metadata\\": {
+          \\"count\\": 2,
+          \\"all\\": \\"https://api.tempo.io/core/3/plans/123?from=2017-07-13&amp;to=2018-12-31\\"
+        },
+        \\"values\\": [
+          {
+            \\"from\\": \\"2017-11-13\\",
+            \\"to\\": \\"2017-11-13\\",
+            \\"timePlannedSeconds\\": 3600
+          },
+          {
+            \\"from\\": \\"2017-12-13\\",
+            \\"to\\": \\"2017-12-13\\",
+            \\"timePlannedSeconds\\": 3600
+          }
+        ]
+      }
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/plans/289\\",
+      \\"id\\": 289,
+      \\"startDate\\": \\"2017-07-13\\",
+      \\"endDate\\": \\"2017-11-13\\",
+      \\"secondsPerDay\\": 14400,
+      \\"includeNonWorkingDays\\": false,
+      \\"description\\": \\"This is a project plan\\",
+      \\"createdAt\\": \\"2017-02-23T15:07:00Z\\",
+      \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\",
+      \\"assignee\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+        \\"type\\": \\"USER\\"
+      },
+      \\"planItem\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/project/1000100\\",
+        \\"type\\": \\"PROJECT\\"
+      },
+      \\"recurrence\\": {
+        \\"rule\\": \\"WEEKLY\\",
+        \\"recurrenceEndDate\\": \\"2018-04-01\\"
+      },
+      \\"dates\\": {
+        \\"metadata\\": {
+          \\"count\\": 7,
+          \\"all\\": \\"https://api.tempo.io/core/3/plans/123?from=2017-07-13&amp;to=2018-04-01\\"
+        },
+        \\"values\\": [
+          {
+            \\"from\\": \\"2017-11-15\\",
+            \\"to\\": \\"2017-11-15\\",
+            \\"timePlannedSeconds\\": 14400
+          },
+          {
+            \\"from\\": \\"2017-11-22\\",
+            \\"to\\": \\"2017-11-22\\",
+            \\"timePlannedSeconds\\": 14400
+          },
+          {
+            \\"from\\": \\"2017-11-29\\",
+            \\"to\\": \\"2017-11-29\\",
+            \\"timePlannedSeconds\\": 14400
+          },
+          {
+            \\"from\\": \\"2017-12-06\\",
+            \\"to\\": \\"2017-12-06\\",
+            \\"timePlannedSeconds\\": 14400
+          },
+          {
+            \\"from\\": \\"2017-12-13\\",
+            \\"to\\": \\"2017-12-13\\",
+            \\"timePlannedSeconds\\": 14400
+          },
+          {
+            \\"from\\": \\"2017-12-20\\",
+            \\"to\\": \\"2017-12-20\\",
+            \\"timePlannedSeconds\\": 14400
+          },
+          {
+            \\"from\\": \\"2017-12-27\\",
+            \\"to\\": \\"2017-12-27\\",
+            \\"timePlannedSeconds\\": 14400
+          }
+        ]
+      }
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"plans_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Creates a new plan</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#plans_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#plans_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#plans_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"plans_post_request\\">
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>startDate</strong>: <em>required (date-only)</em></li>
+<li><strong>endDate</strong>: <em>required (date-only)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>plannedPerDaySeconds</strong>: <em>required (number)</em></li>
+<li><strong>includeNonWorkingDays</strong>: <em>(boolean)</em></li>
+<li><strong>rule</strong>: <em>(one of NEVER, WEEKLY, BI_WEEKLY, MONTHLY)</em></li>
+<li><strong>recurrenceEndDate</strong>: <em>(date-only)</em></li>
+<li><strong>accountId</strong>: <em>required (string)</em></li>
+<li><strong>issueKey</strong>: <em>(string)</em></li>
+<li><strong>projectKey</strong>: <em>(string)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"startDate\\": \\"2017-02-27\\",
+  \\"endDate\\": \\"2017-02-27\\",
+  \\"description\\": \\"Planning to do some work every month on issue ISS-15\\",
+  \\"plannedPerDaySeconds\\": 3600,
+  \\"includeNonWorkingDays\\": false,
+  \\"rule\\": \\"MONTHLY\\",
+  \\"recurrenceEndDate\\": \\"2019-12-31\\",
+  \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+  \\"issueKey\\": \\"ISS-15\\"
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"plans_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Plan has been successfully created</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>startDate</strong>: <em>required (date-only)</em></li>
+<li><strong>endDate</strong>: <em>required (date-only)</em></li>
+<li><strong>secondsPerDay</strong>: <em>required (number)</em></li>
+<li><strong>includeNonWorkingDays</strong>: <em>required (boolean)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>createdAt</strong>: <em>required (datetime)</em></li>
+<li><strong>updatedAt</strong>: <em>required (datetime)</em></li>
+<li><strong>assignee</strong>: <em>required (assignee)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, TEAM)</em></li></ul></li>
+<li><strong>planItem</strong>: <em>required (planItem)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of ISSUE, PROJECT)</em></li></ul></li>
+<li><strong>recurrence</strong>: <em>required (recurrence)</em><ul><li><strong>rule</strong>: <em>required (one of NEVER, WEEKLY, BIWEEKLY, MONTHLY)</em></li><li><strong>recurrenceEndDate</strong>: <em>required (date-only)</em></li></ul></li>
+<li><strong>dates</strong>: <em>required (dates)</em><ul><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>all</strong>: <em>required (string)</em></li></ul></li><li><strong>values</strong>: <em>required (array of PlanPeriod)</em><p><strong>Items</strong>: PlanPeriod</p><div class=\\"items\\"><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li><li><strong>timePlannedSeconds</strong>: <em>required (number)</em></li></ul></div></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/plans/123\\",
+  \\"id\\": 123,
+  \\"startDate\\": \\"2017-12-15\\",
+  \\"endDate\\": \\"2017-12-15\\",
+  \\"secondsPerDay\\": 28800,
+  \\"includeNonWorkingDays\\": false,
+  \\"description\\": \\"This is a plan\\",
+  \\"createdAt\\": \\"2017-02-23T15:07:00Z\\",
+  \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\",
+  \\"assignee\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"type\\": \\"USER\\"
+  },
+  \\"planItem\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/project/1000110\\",
+    \\"type\\": \\"PROJECT\\"
+  },
+  \\"recurrence\\": {
+    \\"rule\\": \\"NEVER\\",
+    \\"recurrenceEndDate\\": \\"2017-12-15\\"
+  },
+  \\"dates\\": {
+    \\"metadata\\": {
+      \\"count\\": 1,
+      \\"all\\": \\"https://api.tempo.io/core/3/plans/123?from=2017-12-15&amp;to=2017-12-15\\"
+    },
+    \\"values\\": [
+      {
+        \\"from\\": \\"2017-12-15\\",
+        \\"to\\": \\"2017-12-15\\",
+        \\"timePlannedSeconds\\": 28800
+      }
+    ]
+  }
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Plan cannot be created for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Issue not found\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"plans_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_plans__id_\\" href=\\"#panel_plans__id_\\"><span class=\\"parent\\">/plans</span>/{id}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_plans__id_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve an existing plan for the given id. Add from and to query params to expand recurrences.</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#plans__id__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#plans__id__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#plans__id__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"plans__id__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>from</strong>: <em>(date-only)</em><p>Retrieve results starting with this date</p></li>
+<li><strong>to</strong>: <em>(date-only)</em><p>Retrieve results up to and including this date</p></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"plans__id__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Plan of the given id</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>startDate</strong>: <em>required (date-only)</em></li>
+<li><strong>endDate</strong>: <em>required (date-only)</em></li>
+<li><strong>secondsPerDay</strong>: <em>required (number)</em></li>
+<li><strong>includeNonWorkingDays</strong>: <em>required (boolean)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>createdAt</strong>: <em>required (datetime)</em></li>
+<li><strong>updatedAt</strong>: <em>required (datetime)</em></li>
+<li><strong>assignee</strong>: <em>required (assignee)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, TEAM)</em></li></ul></li>
+<li><strong>planItem</strong>: <em>required (planItem)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of ISSUE, PROJECT)</em></li></ul></li>
+<li><strong>recurrence</strong>: <em>required (recurrence)</em><ul><li><strong>rule</strong>: <em>required (one of NEVER, WEEKLY, BIWEEKLY, MONTHLY)</em></li><li><strong>recurrenceEndDate</strong>: <em>required (date-only)</em></li></ul></li>
+<li><strong>dates</strong>: <em>required (dates)</em><ul><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>all</strong>: <em>required (string)</em></li></ul></li><li><strong>values</strong>: <em>required (array of PlanPeriod)</em><p><strong>Items</strong>: PlanPeriod</p><div class=\\"items\\"><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li><li><strong>timePlannedSeconds</strong>: <em>required (number)</em></li></ul></div></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/plans/123\\",
+  \\"id\\": 123,
+  \\"startDate\\": \\"2017-12-15\\",
+  \\"endDate\\": \\"2017-12-15\\",
+  \\"secondsPerDay\\": 28800,
+  \\"includeNonWorkingDays\\": false,
+  \\"description\\": \\"This is a plan\\",
+  \\"createdAt\\": \\"2017-02-23T15:07:00Z\\",
+  \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\",
+  \\"assignee\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"type\\": \\"USER\\"
+  },
+  \\"planItem\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/project/1000110\\",
+    \\"type\\": \\"PROJECT\\"
+  },
+  \\"recurrence\\": {
+    \\"rule\\": \\"NEVER\\",
+    \\"recurrenceEndDate\\": \\"2017-12-15\\"
+  },
+  \\"dates\\": {
+    \\"metadata\\": {
+      \\"count\\": 1,
+      \\"all\\": \\"https://api.tempo.io/core/3/plans/123?from=2017-12-15&amp;to=2017-12-15\\"
+    },
+    \\"values\\": [
+      {
+        \\"from\\": \\"2017-12-15\\",
+        \\"to\\": \\"2017-12-15\\",
+        \\"timePlannedSeconds\\": 28800
+      }
+    ]
+  }
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Plan cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Allocation not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"plans__id__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Update an existing plan for the given id</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#plans__id__put_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#plans__id__put_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#plans__id__put_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"plans__id__put_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>startDate</strong>: <em>required (date-only)</em></li>
+<li><strong>endDate</strong>: <em>required (date-only)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>plannedPerDaySeconds</strong>: <em>required (number)</em></li>
+<li><strong>includeNonWorkingDays</strong>: <em>(boolean)</em></li>
+<li><strong>rule</strong>: <em>(one of NEVER, WEEKLY, BI_WEEKLY, MONTHLY)</em></li>
+<li><strong>recurrenceEndDate</strong>: <em>(date-only)</em></li>
+<li><strong>accountId</strong>: <em>required (string)</em></li>
+<li><strong>issueKey</strong>: <em>(string)</em></li>
+<li><strong>projectKey</strong>: <em>(string)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"startDate\\": \\"2017-02-27\\",
+  \\"endDate\\": \\"2017-02-27\\",
+  \\"description\\": \\"Planning to do some work every month on issue ISS-15\\",
+  \\"plannedPerDaySeconds\\": 3600,
+  \\"includeNonWorkingDays\\": false,
+  \\"rule\\": \\"MONTHLY\\",
+  \\"recurrenceEndDate\\": \\"2019-12-31\\",
+  \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+  \\"issueKey\\": \\"ISS-15\\"
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"plans__id__put_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Plan has been successfully updated</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>startDate</strong>: <em>required (date-only)</em></li>
+<li><strong>endDate</strong>: <em>required (date-only)</em></li>
+<li><strong>secondsPerDay</strong>: <em>required (number)</em></li>
+<li><strong>includeNonWorkingDays</strong>: <em>required (boolean)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>createdAt</strong>: <em>required (datetime)</em></li>
+<li><strong>updatedAt</strong>: <em>required (datetime)</em></li>
+<li><strong>assignee</strong>: <em>required (assignee)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, TEAM)</em></li></ul></li>
+<li><strong>planItem</strong>: <em>required (planItem)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of ISSUE, PROJECT)</em></li></ul></li>
+<li><strong>recurrence</strong>: <em>required (recurrence)</em><ul><li><strong>rule</strong>: <em>required (one of NEVER, WEEKLY, BIWEEKLY, MONTHLY)</em></li><li><strong>recurrenceEndDate</strong>: <em>required (date-only)</em></li></ul></li>
+<li><strong>dates</strong>: <em>required (dates)</em><ul><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>all</strong>: <em>required (string)</em></li></ul></li><li><strong>values</strong>: <em>required (array of PlanPeriod)</em><p><strong>Items</strong>: PlanPeriod</p><div class=\\"items\\"><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li><li><strong>timePlannedSeconds</strong>: <em>required (number)</em></li></ul></div></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/plans/123\\",
+  \\"id\\": 123,
+  \\"startDate\\": \\"2017-12-15\\",
+  \\"endDate\\": \\"2017-12-15\\",
+  \\"secondsPerDay\\": 28800,
+  \\"includeNonWorkingDays\\": false,
+  \\"description\\": \\"This is a plan\\",
+  \\"createdAt\\": \\"2017-02-23T15:07:00Z\\",
+  \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\",
+  \\"assignee\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"type\\": \\"USER\\"
+  },
+  \\"planItem\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/project/1000110\\",
+    \\"type\\": \\"PROJECT\\"
+  },
+  \\"recurrence\\": {
+    \\"rule\\": \\"NEVER\\",
+    \\"recurrenceEndDate\\": \\"2017-12-15\\"
+  },
+  \\"dates\\": {
+    \\"metadata\\": {
+      \\"count\\": 1,
+      \\"all\\": \\"https://api.tempo.io/core/3/plans/123?from=2017-12-15&amp;to=2017-12-15\\"
+    },
+    \\"values\\": [
+      {
+        \\"from\\": \\"2017-12-15\\",
+        \\"to\\": \\"2017-12-15\\",
+        \\"timePlannedSeconds\\": 28800
+      }
+    ]
+  }
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Plan cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Allocation not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"plans__id__put_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Delete an existing plan</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#plans__id__delete_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#plans__id__delete_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#plans__id__delete_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"plans__id__delete_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"plans__id__delete_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
+<p>Plan has been successfully deleted</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Plan cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Allocation not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"plans__id__delete_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_plans_user__accountid_\\" href=\\"#panel_plans_user__accountid_\\"><span class=\\"parent\\">/plans</span>/user/{accountId}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_plans_user__accountid_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve plans for user</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#plans_user__accountid__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#plans_user__accountid__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#plans_user__accountid__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"plans_user__accountid__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>accountId</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>from</strong>: <em>required (date-only)</em><p>Retrieve results starting with this date</p></li>
+<li><strong>to</strong>: <em>required (date-only)</em><p>Retrieve results up to and including this date</p></li>
+<li><strong>updatedFrom</strong>: <em>(date-only)</em><p>Retrieve results that have been updated from this date</p></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"plans_user__accountid__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>List of plans</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Plan)</em><p><strong>Items</strong>: Plan</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>endDate</strong>: <em>required (date-only)</em></li><li><strong>secondsPerDay</strong>: <em>required (number)</em></li><li><strong>includeNonWorkingDays</strong>: <em>required (boolean)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>assignee</strong>: <em>required (assignee)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of USER, TEAM)</em></li></ul></li><li><strong>planItem</strong>: <em>required (planItem)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of ISSUE, PROJECT)</em></li></ul></li><li><strong>recurrence</strong>: <em>required (recurrence)</em><ul><li><strong>rule</strong>: <em>required (one of NEVER, WEEKLY, BIWEEKLY, MONTHLY)</em></li><li><strong>recurrenceEndDate</strong>: <em>required (date-only)</em></li></ul></li><li><strong>dates</strong>: <em>required (dates)</em><ul><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>all</strong>: <em>required (string)</em></li></ul></li><li><strong>values</strong>: <em>required (array of PlanPeriod)</em><p><strong>Items</strong>: PlanPeriod</p><div class=\\"items\\"><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li><li><strong>timePlannedSeconds</strong>: <em>required (number)</em></li></ul></div></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/plans/user/1111aaaa2222bbbb3333cccc?from=2017-11-01&amp;to=2017-12-31\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/plans/223\\",
+      \\"id\\": 223,
+      \\"startDate\\": \\"2017-07-13\\",
+      \\"endDate\\": \\"2017-11-13\\",
+      \\"secondsPerDay\\": 3600,
+      \\"includeNonWorkingDays\\": false,
+      \\"description\\": \\"This is an issue plan\\",
+      \\"createdAt\\": \\"2017-02-23T15:07:00Z\\",
+      \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\",
+      \\"assignee\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+        \\"type\\": \\"USER\\"
+      },
+      \\"planItem\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/issue/ISS-555\\",
+        \\"type\\": \\"ISSUE\\"
+      },
+      \\"recurrence\\": {
+        \\"rule\\": \\"MONTHLY\\",
+        \\"recurrenceEndDate\\": \\"2018-12-31\\"
+      },
+      \\"dates\\": {
+        \\"metadata\\": {
+          \\"count\\": 2,
+          \\"all\\": \\"https://api.tempo.io/core/3/plans/123?from=2017-07-13&amp;to=2018-12-31\\"
+        },
+        \\"values\\": [
+          {
+            \\"from\\": \\"2017-11-13\\",
+            \\"to\\": \\"2017-11-13\\",
+            \\"timePlannedSeconds\\": 3600
+          },
+          {
+            \\"from\\": \\"2017-12-13\\",
+            \\"to\\": \\"2017-12-13\\",
+            \\"timePlannedSeconds\\": 3600
+          }
+        ]
+      }
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/plans/289\\",
+      \\"id\\": 289,
+      \\"startDate\\": \\"2017-07-13\\",
+      \\"endDate\\": \\"2017-11-13\\",
+      \\"secondsPerDay\\": 14400,
+      \\"includeNonWorkingDays\\": false,
+      \\"description\\": \\"This is a project plan\\",
+      \\"createdAt\\": \\"2017-02-23T15:07:00Z\\",
+      \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\",
+      \\"assignee\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+        \\"type\\": \\"USER\\"
+      },
+      \\"planItem\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/project/1000100\\",
+        \\"type\\": \\"PROJECT\\"
+      },
+      \\"recurrence\\": {
+        \\"rule\\": \\"WEEKLY\\",
+        \\"recurrenceEndDate\\": \\"2018-04-01\\"
+      },
+      \\"dates\\": {
+        \\"metadata\\": {
+          \\"count\\": 7,
+          \\"all\\": \\"https://api.tempo.io/core/3/plans/123?from=2017-07-13&amp;to=2018-04-01\\"
+        },
+        \\"values\\": [
+          {
+            \\"from\\": \\"2017-11-15\\",
+            \\"to\\": \\"2017-11-15\\",
+            \\"timePlannedSeconds\\": 14400
+          },
+          {
+            \\"from\\": \\"2017-11-22\\",
+            \\"to\\": \\"2017-11-22\\",
+            \\"timePlannedSeconds\\": 14400
+          },
+          {
+            \\"from\\": \\"2017-11-29\\",
+            \\"to\\": \\"2017-11-29\\",
+            \\"timePlannedSeconds\\": 14400
+          },
+          {
+            \\"from\\": \\"2017-12-06\\",
+            \\"to\\": \\"2017-12-06\\",
+            \\"timePlannedSeconds\\": 14400
+          },
+          {
+            \\"from\\": \\"2017-12-13\\",
+            \\"to\\": \\"2017-12-13\\",
+            \\"timePlannedSeconds\\": 14400
+          },
+          {
+            \\"from\\": \\"2017-12-20\\",
+            \\"to\\": \\"2017-12-20\\",
+            \\"timePlannedSeconds\\": 14400
+          },
+          {
+            \\"from\\": \\"2017-12-27\\",
+            \\"to\\": \\"2017-12-27\\",
+            \\"timePlannedSeconds\\": 14400
+          }
+        ]
+      }
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"plans_user__accountid__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h2 class=\\"sg-h2\\" id=\\"programs\\">Programs</h2>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_programs\\" href=\\"#panel_programs\\"><span class=\\"parent\\"></span>/programs</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_programs\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve all programs</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#programs_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#programs_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"programs_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>List of all programs</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Program)</em><p><strong>Items</strong>: Program</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>manager</strong>: <em>(manager)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>teams</strong>: <em>required (teams)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>values</strong>: <em>required (array of TeamRef)</em><p><strong>Items</strong>: TeamRef</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></div></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/programs\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/programs/1\\",
+      \\"id\\": 1,
+      \\"name\\": \\"P1\\",
+      \\"manager\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+        \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+        \\"displayName\\": \\"John Brown\\"
+      },
+      \\"teams\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/programs/1/teams\\",
+        \\"values\\": [
+          {
+            \\"self\\": \\"https://api.tempo.io/core/3/teams/101\\",
+            \\"id\\": 101,
+            \\"name\\": \\"Developer\\"
+          }
+        ]
+      }
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/programs/2\\",
+      \\"id\\": 2,
+      \\"name\\": \\"P2\\",
+      \\"manager\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+        \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+        \\"displayName\\": \\"John Brown\\"
+      },
+      \\"teams\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/programs/2/teams\\",
+        \\"values\\": [
+          {
+            \\"self\\": \\"https://api.tempo.io/core/3/teams/103\\",
+            \\"id\\": 103,
+            \\"name\\": \\"QA\\"
+          }
+        ]
+      }
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"programs_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Creates a new program</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#programs_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#programs_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#programs_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"programs_post_request\\">
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>managerAccountId</strong>: <em>(string)</em></li>
+<li><strong>teamIds</strong>: <em>(array of )</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"name\\": \\"P1\\",
+  \\"managerAccountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+  \\"teamIds\\": [
+    101
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"programs_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Program has been successfully created</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>manager</strong>: <em>(manager)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>teams</strong>: <em>required (teams)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>values</strong>: <em>required (array of TeamRef)</em><p><strong>Items</strong>: TeamRef</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></div></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/programs/1\\",
+  \\"id\\": 1,
+  \\"name\\": \\"P1\\",
+  \\"manager\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+    \\"displayName\\": \\"John Brown\\"
+  },
+  \\"teams\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/programs/1/teams\\",
+    \\"values\\": [
+      {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/101\\",
+        \\"id\\": 101,
+        \\"name\\": \\"Developer\\"
+      }
+    ]
+  }
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Program cannot be created for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Program name is required\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"programs_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_programs__id_\\" href=\\"#panel_programs__id_\\"><span class=\\"parent\\">/programs</span>/{id}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_programs__id_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve an existing program for the given id</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#programs__id__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#programs__id__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#programs__id__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"programs__id__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"programs__id__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Program data of the given id</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>manager</strong>: <em>(manager)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>teams</strong>: <em>required (teams)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>values</strong>: <em>required (array of TeamRef)</em><p><strong>Items</strong>: TeamRef</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></div></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/programs/1\\",
+  \\"id\\": 1,
+  \\"name\\": \\"P1\\",
+  \\"manager\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+    \\"displayName\\": \\"John Brown\\"
+  },
+  \\"teams\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/programs/1/teams\\",
+    \\"values\\": [
+      {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/101\\",
+        \\"id\\": 101,
+        \\"name\\": \\"Developer\\"
+      }
+    ]
+  }
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Program cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Program not found\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"programs__id__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Update an existing program for the given id</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#programs__id__put_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#programs__id__put_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#programs__id__put_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"programs__id__put_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>managerAccountId</strong>: <em>(string)</em></li>
+<li><strong>teamIds</strong>: <em>(array of )</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"name\\": \\"P1\\",
+  \\"managerAccountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+  \\"teamIds\\": [
+    101
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"programs__id__put_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Program has been successfully updated</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>manager</strong>: <em>(manager)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>teams</strong>: <em>required (teams)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>values</strong>: <em>required (array of TeamRef)</em><p><strong>Items</strong>: TeamRef</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></div></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/programs/1\\",
+  \\"id\\": 1,
+  \\"name\\": \\"P1\\",
+  \\"manager\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+    \\"displayName\\": \\"John Brown\\"
+  },
+  \\"teams\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/programs/1/teams\\",
+    \\"values\\": [
+      {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/101\\",
+        \\"id\\": 101,
+        \\"name\\": \\"Developer\\"
+      }
+    ]
+  }
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Program cannot be updated for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Program name is required\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Program cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Program not found\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"programs__id__put_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Delete an existing program</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#programs__id__delete_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#programs__id__delete_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#programs__id__delete_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"programs__id__delete_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"programs__id__delete_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
+<p>Program has been successfully deleted</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Program cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Program not found\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"programs__id__delete_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_programs__id__teams\\" href=\\"#panel_programs__id__teams\\"><span class=\\"parent\\">/programs/{id}</span>/teams</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_programs__id__teams\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve teams associated to this program</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#programs__id__teams_get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#programs__id__teams_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#programs__id__teams_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"programs__id__teams_get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"programs__id__teams_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>List of teams associated to the program</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of TeamRef)</em><p><strong>Items</strong>: TeamRef</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/programs/3/teams\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/teams/12\\",
+      \\"id\\": 12,
+      \\"name\\": \\"Design\\"
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/teams/43\\",
+      \\"id\\": 43,
+      \\"name\\": \\"Analyst\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"programs__id__teams_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h2 class=\\"sg-h2\\" id=\\"roles\\">Roles</h2>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_roles\\" href=\\"#panel_roles\\"><span class=\\"parent\\"></span>/roles</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_roles\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve all roles</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#roles_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#roles_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"roles_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>List of all roles</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Team Role)</em><p><strong>Items</strong>: Team Role</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>default</strong>: <em>required (boolean)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/roles\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/roles/1\\",
+      \\"id\\": 1,
+      \\"name\\": \\"Developer\\",
+      \\"default\\": true
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/roles/2\\",
+      \\"id\\": 2,
+      \\"name\\": \\"Manager\\",
+      \\"default\\": false
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"roles_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Creates a new role</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#roles_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#roles_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#roles_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"roles_post_request\\">
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>name</strong>: <em>required (string)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"name\\": \\"Developer\\"
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"roles_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Role has been successfully created</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>default</strong>: <em>required (boolean)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/roles/2\\",
+  \\"id\\": 2,
+  \\"name\\": \\"Manager\\",
+  \\"default\\": false
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Role cannot be created for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Role name cannot be blank\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"roles_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_roles_default\\" href=\\"#panel_roles_default\\"><span class=\\"parent\\">/roles</span>/default</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_roles_default\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve the default role</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#roles_default_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#roles_default_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"roles_default_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Default Role</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>default</strong>: <em>required (boolean)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/roles/1\\",
+  \\"id\\": 1,
+  \\"name\\": \\"Member\\",
+  \\"default\\": true
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"roles_default_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_roles__id_\\" href=\\"#panel_roles__id_\\"><span class=\\"parent\\">/roles</span>/{id}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_roles__id_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve an existing role for the given id</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#roles__id__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#roles__id__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#roles__id__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"roles__id__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"roles__id__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Role data of the given id</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>default</strong>: <em>required (boolean)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/roles/2\\",
+  \\"id\\": 2,
+  \\"name\\": \\"Manager\\",
+  \\"default\\": false
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Role cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Role not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"roles__id__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Update an existing role for the given id</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#roles__id__put_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#roles__id__put_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#roles__id__put_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"roles__id__put_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>name</strong>: <em>required (string)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"name\\": \\"Developer\\"
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"roles__id__put_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Role has been successfully updated</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>default</strong>: <em>required (boolean)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/roles/2\\",
+  \\"id\\": 2,
+  \\"name\\": \\"Manager\\",
+  \\"default\\": false
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Role cannot be updated for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Role name cannot be blank\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Role cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Role not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"roles__id__put_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Delete an existing role</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#roles__id__delete_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#roles__id__delete_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#roles__id__delete_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"roles__id__delete_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"roles__id__delete_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
+<p>Role has been successfully deleted</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Role cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Role not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"roles__id__delete_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h2 class=\\"sg-h2\\" id=\\"teams\\">Teams</h2>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_teams\\" href=\\"#panel_teams\\"><span class=\\"parent\\"></span>/teams</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_teams\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Creates a new team</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#teams_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#teams_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#teams_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"teams_post_request\\">
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>summary</strong>: <em>(string)</em></li>
+<li><strong>leadAccountId</strong>: <em>(string)</em></li>
+<li><strong>programId</strong>: <em>(integer)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"name\\": \\"Team-A\\",
+  \\"summary\\": \\"This is the A team\\",
+  \\"leadAccountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+  \\"programId\\": 42
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Team has been successfully created</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>summary</strong>: <em>(string)</em></li>
+<li><strong>lead</strong>: <em>(lead)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>program</strong>: <em>(program)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>links</strong>: <em>required (links)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>members</strong>: <em>required (members)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>permissions</strong>: <em>required (permissions)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/teams/1\\",
+  \\"id\\": 1,
+  \\"name\\": \\"Team-A\\",
+  \\"summary\\": \\"This is the A team\\",
+  \\"lead\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+    \\"displayName\\": \\"John Brown\\"
+  },
+  \\"program\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/programs/42\\",
+    \\"id\\": 42,
+    \\"name\\": \\"Dev\\"
+  },
+  \\"links\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/teams/1/links\\"
+  },
+  \\"members\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/teams/1/members\\"
+  },
+  \\"permissions\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/teams/1/permissions\\"
+  }
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Team cannot be created for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Team with that name (&#39;Team-A&#39;) already exists\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve all teams</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#teams_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#teams_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"teams_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>List of all teams the user is allowed to browse</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Team)</em><p><strong>Items</strong>: Team</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>summary</strong>: <em>(string)</em></li><li><strong>lead</strong>: <em>(lead)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>program</strong>: <em>(program)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li><li><strong>links</strong>: <em>required (links)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>members</strong>: <em>required (members)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>permissions</strong>: <em>required (permissions)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/teams\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/teams/1\\",
+      \\"id\\": 1,
+      \\"name\\": \\"Team-A\\",
+      \\"summary\\": \\"This is the A team\\",
+      \\"lead\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+        \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+        \\"displayName\\": \\"John Brown\\"
+      },
+      \\"program\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/programs/42\\",
+        \\"id\\": 42,
+        \\"name\\": \\"Devs\\"
+      },
+      \\"links\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/1/links\\"
+      },
+      \\"members\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/1/members\\"
+      },
+      \\"permissions\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/1/permissions\\"
+      }
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/teams/2\\",
+      \\"id\\": 2,
+      \\"name\\": \\"Team-B\\",
+      \\"links\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/2/links\\"
+      },
+      \\"members\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/2/members\\"
+      },
+      \\"permissions\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/2/permissions\\"
+      }
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_teams__id_\\" href=\\"#panel_teams__id_\\"><span class=\\"parent\\">/teams</span>/{id}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_teams__id_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve an existing team for the given id</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#teams__id__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#teams__id__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#teams__id__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"teams__id__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams__id__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Team of the given id</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>summary</strong>: <em>(string)</em></li>
+<li><strong>lead</strong>: <em>(lead)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>program</strong>: <em>(program)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>links</strong>: <em>required (links)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>members</strong>: <em>required (members)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>permissions</strong>: <em>required (permissions)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/teams/1\\",
+  \\"id\\": 1,
+  \\"name\\": \\"Team-A\\",
+  \\"summary\\": \\"This is the A team\\",
+  \\"lead\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+    \\"displayName\\": \\"John Brown\\"
+  },
+  \\"program\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/programs/42\\",
+    \\"id\\": 42,
+    \\"name\\": \\"Dev\\"
+  },
+  \\"links\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/teams/1/links\\"
+  },
+  \\"members\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/teams/1/members\\"
+  },
+  \\"permissions\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/teams/1/permissions\\"
+  }
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Team cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Team not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams__id__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Update an existing team for the given id</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#teams__id__put_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#teams__id__put_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#teams__id__put_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"teams__id__put_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>summary</strong>: <em>(string)</em></li>
+<li><strong>leadAccountId</strong>: <em>(string)</em></li>
+<li><strong>programId</strong>: <em>(integer)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"name\\": \\"Team-A\\",
+  \\"summary\\": \\"This is the A team\\",
+  \\"leadAccountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+  \\"programId\\": 42
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams__id__put_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Team has been successfully updated</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>summary</strong>: <em>(string)</em></li>
+<li><strong>lead</strong>: <em>(lead)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>program</strong>: <em>(program)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>links</strong>: <em>required (links)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>members</strong>: <em>required (members)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>permissions</strong>: <em>required (permissions)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/teams/1\\",
+  \\"id\\": 1,
+  \\"name\\": \\"Team-A\\",
+  \\"summary\\": \\"This is the A team\\",
+  \\"lead\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+    \\"displayName\\": \\"John Brown\\"
+  },
+  \\"program\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/programs/42\\",
+    \\"id\\": 42,
+    \\"name\\": \\"Dev\\"
+  },
+  \\"links\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/teams/1/links\\"
+  },
+  \\"members\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/teams/1/members\\"
+  },
+  \\"permissions\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/teams/1/permissions\\"
+  }
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Team cannot be updated for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Team with that name (&#39;Team-A&#39;) already exists\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Team cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Team not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams__id__put_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Delete an existing team</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#teams__id__delete_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#teams__id__delete_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#teams__id__delete_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"teams__id__delete_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams__id__delete_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
+<p>Team has been successfully deleted</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Team cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Team not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams__id__delete_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_teams__id__links\\" href=\\"#panel_teams__id__links\\"><span class=\\"parent\\">/teams/{id}</span>/links</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_teams__id__links\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve all the links for this team</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#teams__id__links_get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#teams__id__links_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#teams__id__links_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"teams__id__links_get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams__id__links_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Team&#39;s links</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of TeamLinkRef)</em><p><strong>Items</strong>: TeamLinkRef</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (number)</em></li><li><strong>scope</strong>: <em>required (scope)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (number)</em></li><li><strong>type</strong>: <em>required (one of BOARD, PROJECT)</em></li></ul></li><li><strong>team</strong>: <em>required (team)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/teams/14/links\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/team-links/1\\",
+      \\"id\\": 1,
+      \\"scope\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/project/PRJ-1\\",
+        \\"id\\": 100100,
+        \\"type\\": \\"PROJECT\\"
+      },
+      \\"team\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/14\\"
+      }
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/team-links/3\\",
+      \\"id\\": 3,
+      \\"scope\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/agile/1.0/board/123456\\",
+        \\"id\\": 123456,
+        \\"type\\": \\"BOARD\\"
+      },
+      \\"team\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/14\\"
+      }
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Team cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Team not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams__id__links_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_teams__id__members\\" href=\\"#panel_teams__id__members\\"><span class=\\"parent\\">/teams/{id}</span>/members</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_teams__id__members\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve all the members for this team with their active membership</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#teams__id__members_get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#teams__id__members_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#teams__id__members_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"teams__id__members_get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams__id__members_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Team&#39;s members</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Team Member Active Membership)</em><p><strong>Items</strong>: Team Member Active Membership</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>team</strong>: <em>required (team)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>member</strong>: <em>required (member)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>memberships</strong>: <em>required (memberships)</em><ul><li><strong>self</strong>: <em>required (self)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>active</strong>: <em>(active)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>commitmentPercent</strong>: <em>required (integer)</em></li><li><strong>from</strong>: <em>(date-only)</em></li><li><strong>to</strong>: <em>(date-only)</em></li><li><strong>role</strong>: <em>required (role)</em><ul><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>self</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li></ul></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/teams/1/members\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/teams/1/members/1111aaaa2222bbbb3333cccc\\",
+      \\"team\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/1\\"
+      },
+      \\"member\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+        \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+        \\"displayName\\": \\"John Brown\\"
+      },
+      \\"memberships\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/1/members/1111aaaa2222bbbb3333cccc/memberships\\",
+        \\"active\\": {
+          \\"self\\": \\"https://api.tempo.io/core/3/team-memberships/3\\",
+          \\"id\\": 3,
+          \\"commitmentPercent\\": 100,
+          \\"from\\": null,
+          \\"to\\": null,
+          \\"role\\": {
+            \\"self\\": \\"https://api.tempo.io/core/3/roles/1\\",
+            \\"id\\": 1,
+            \\"name\\": \\"Tester\\"
+          }
+        }
+      }
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/teams/1/members/123456:01234567-89ab-cdef-0123-456789abcdef\\",
+      \\"team\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/1\\"
+      },
+      \\"member\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+        \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+        \\"displayName\\": \\"Erica Jefferson\\"
+      },
+      \\"memberships\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/1/members/123456:01234567-89ab-cdef-0123-456789abcdef/memberships\\"
+      }
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Team cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Team not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams__id__members_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_teams__id__members__accountid_\\" href=\\"#panel_teams__id__members__accountid_\\"><span class=\\"parent\\">/teams/{id}/members</span>/{accountId}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_teams__id__members__accountid_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve the member&#39;s active membership for this team</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#teams__id__members__accountid__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#teams__id__members__accountid__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#teams__id__members__accountid__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"teams__id__members__accountid__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+<li><strong>accountId</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams__id__members__accountid__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Member&#39;s active membership for this team</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>team</strong>: <em>required (team)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>member</strong>: <em>required (member)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>memberships</strong>: <em>required (memberships)</em><ul><li><strong>self</strong>: <em>required (self)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>active</strong>: <em>(active)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>commitmentPercent</strong>: <em>required (integer)</em></li><li><strong>from</strong>: <em>(date-only)</em></li><li><strong>to</strong>: <em>(date-only)</em></li><li><strong>role</strong>: <em>required (role)</em><ul><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>self</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li></ul></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/teams/1/members/1111aaaa2222bbbb3333cccc\\",
+  \\"team\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/teams/1\\"
+  },
+  \\"member\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+    \\"displayName\\": \\"John Brown\\"
+  },
+  \\"memberships\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/teams/1/members/1111aaaa2222bbbb3333cccc/memberships\\",
+    \\"active\\": {
+      \\"self\\": \\"https://api.tempo.io/core/3/team-memberships/1\\",
+      \\"id\\": 1,
+      \\"commitmentPercent\\": 100,
+      \\"from\\": null,
+      \\"to\\": null,
+      \\"role\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/roles/1\\",
+        \\"id\\": 1,
+        \\"name\\": \\"Tester\\"
+      }
+    }
+  }
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Team cannot be found in the system or user is not a member of this team</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Team not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams__id__members__accountid__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_teams__id__members__accountid__memberships\\" href=\\"#panel_teams__id__members__accountid__memberships\\"><span class=\\"parent\\">/teams/{id}/members/{accountId}</span>/memberships</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_teams__id__members__accountid__memberships\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve member&#39;s memberships for this team</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#teams__id__members__accountid__memberships_get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#teams__id__members__accountid__memberships_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#teams__id__members__accountid__memberships_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"teams__id__members__accountid__memberships_get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+<li><strong>accountId</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams__id__members__accountid__memberships_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Member&#39;s memberships for this team</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Team Member Membership)</em><p><strong>Items</strong>: Team Member Membership</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>commitmentPercent</strong>: <em>required (integer)</em></li><li><strong>from</strong>: <em>(date-only)</em></li><li><strong>to</strong>: <em>(date-only)</em></li><li><strong>role</strong>: <em>required (role)</em><ul><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>self</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li><li><strong>team</strong>: <em>(team)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>member</strong>: <em>(member)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/teams/1/members/1111aaaa2222bbbb3333cccc/memberships\\",
+  \\"metadata\\": {
+    \\"count\\": 3
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/team-memberships/1\\",
+      \\"id\\": 1,
+      \\"commitmentPercent\\": 100,
+      \\"from\\": \\"2016-01-01\\",
+      \\"to\\": \\"2016-12-31\\",
+      \\"role\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/roles/1\\",
+        \\"id\\": 1,
+        \\"name\\": \\"Tester\\"
+      },
+      \\"team\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/1\\"
+      },
+      \\"member\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\"
+      }
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/team-memberships/2\\",
+      \\"id\\": 2,
+      \\"commitmentPercent\\": 50,
+      \\"from\\": \\"2017-06-01\\",
+      \\"to\\": \\"2017-12-31\\",
+      \\"role\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/roles/2\\",
+        \\"id\\": 2,
+        \\"name\\": \\"Developer\\"
+      },
+      \\"team\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/1\\"
+      },
+      \\"member\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\"
+      }
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/team-memberships/3\\",
+      \\"id\\": 3,
+      \\"commitmentPercent\\": 100,
+      \\"from\\": \\"2018-01-01\\",
+      \\"to\\": \\"2018-12-31\\",
+      \\"role\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/roles/1\\",
+        \\"id\\": 1,
+        \\"name\\": \\"Tester\\"
+      },
+      \\"team\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/1\\"
+      },
+      \\"member\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\"
+      }
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Team cannot be found in the system or user is not a member of this team</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Team not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams__id__members__accountid__memberships_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_teams__id__permissions\\" href=\\"#panel_teams__id__permissions\\"><span class=\\"parent\\">/teams/{id}</span>/permissions</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_teams__id__permissions\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve all the permissions for this team</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#teams__id__permissions_get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#teams__id__permissions_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#teams__id__permissions_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"teams__id__permissions_get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams__id__permissions_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Team&#39;s permissions</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of TeamPermission)</em><p><strong>Items</strong>: TeamPermission</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>users</strong>: <em>required (users)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>values</strong>: <em>required (array of User)</em><p><strong>Items</strong>: User</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></div></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<p><strong>14</strong>:<br></br><pre><code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/teams/14/permissions\\",
+  \\"metadata\\": {
+    \\"count\\": 3
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/teams/14/permissions/permissions.worklog.view\\",
+      \\"key\\": \\"permissions.worklog.view\\",
+      \\"users\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/14/permissions/permissions.worklog.view/users\\",
+        \\"values\\": [
+          {
+            \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+            \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+            \\"displayName\\": \\"Erica Jefferson\\"
+          },
+          {
+            \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+            \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+            \\"displayName\\": \\"John Brown\\"
+          }
+        ]
+      }
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/teams/14/permissions/tempo.timesheets.approve.timesheet\\",
+      \\"key\\": \\"tempo.timesheets.approve.timesheet\\",
+      \\"users\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/14/permissions/tempo.timesheets.approve.timesheet/users\\",
+        \\"values\\": [
+          {
+            \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+            \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+            \\"displayName\\": \\"John Brown\\"
+          }
+        ]
+      }
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/teams/14/permissions/tempo.planner.plan.permission\\",
+      \\"key\\": \\"tempo.planner.plan.permission\\",
+      \\"users\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/14/permissions/tempo.planner.plan.permission/users\\",
+        \\"values\\": [
+          {
+            \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+            \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+            \\"displayName\\": \\"John Brown\\"
+          }
+        ]
+      }
+    }
+  ]
+}
+</code></pre></p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Team cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Team not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams__id__permissions_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_teams__id__permissions__key_\\" href=\\"#panel_teams__id__permissions__key_\\"><span class=\\"parent\\">/teams/{id}/permissions</span>/{key}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_teams__id__permissions__key_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve a specific permission belonging to the team</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#teams__id__permissions__key__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#teams__id__permissions__key__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#teams__id__permissions__key__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"teams__id__permissions__key__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+<li><strong>key</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams__id__permissions__key__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Team&#39;s permission</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>users</strong>: <em>required (users)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>values</strong>: <em>required (array of User)</em><p><strong>Items</strong>: User</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></div></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<p><strong>permissions.worklog.view</strong>:<br></br><pre><code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/teams/14/permissions/permissions.worklog.view\\",
+  \\"key\\": \\"permissions.worklog.view\\",
+  \\"users\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/teams/14/permissions/permissions.worklog.view/users\\",
+    \\"values\\": [
+      {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+        \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+        \\"displayName\\": \\"Erica Jefferson\\"
+      },
+      {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+        \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+        \\"displayName\\": \\"John Brown\\"
+      }
+    ]
+  }
+}
+</code></pre></p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Team or permission cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Permission tempo.teams.browse.team not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"teams__id__permissions__key__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h2 class=\\"sg-h2\\" id=\\"team_links\\">Team - Links</h2>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_team_links\\" href=\\"#panel_team_links\\"><span class=\\"parent\\"></span>/team-links</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_team_links\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Creates a new team-link</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#team_links_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#team_links_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#team_links_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"team_links_post_request\\">
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>teamId</strong>: <em>required (integer)</em></li>
+<li><strong>scopeType</strong>: <em>required (one of BOARD, PROJECT)</em></li>
+<li><strong>scopeId</strong>: <em>required (number)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"teamId\\": 14,
+  \\"scopeType\\": \\"PROJECT\\",
+  \\"scopeId\\": 100100
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"team_links_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Team-link has been successfully-created</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (number)</em></li>
+<li><strong>scope</strong>: <em>required (scope)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (number)</em></li><li><strong>type</strong>: <em>required (one of BOARD, PROJECT)</em></li></ul></li>
+<li><strong>team</strong>: <em>required (team)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/team-links/1\\",
+  \\"id\\": 1,
+  \\"scope\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/2/project/PRJ-1\\",
+    \\"id\\": 100100,
+    \\"type\\": \\"PROJECT\\"
+  },
+  \\"team\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/teams/14\\",
+    \\"id\\": 14,
+    \\"name\\": \\"Team-A\\"
+  }
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Team-link cannot be created for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"You do not have permission to browse Project connected to the link\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"team_links_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_team_links__id_\\" href=\\"#panel_team_links__id_\\"><span class=\\"parent\\">/team-links</span>/{id}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_team_links__id_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve an existing team-link for the given id</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#team_links__id__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#team_links__id__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#team_links__id__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"team_links__id__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"team_links__id__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Retrieve a team-link</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (number)</em></li>
+<li><strong>scope</strong>: <em>required (scope)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (number)</em></li><li><strong>type</strong>: <em>required (one of BOARD, PROJECT)</em></li></ul></li>
+<li><strong>team</strong>: <em>required (team)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/team-links/1\\",
+  \\"id\\": 1,
+  \\"scope\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/2/project/PRJ-1\\",
+    \\"id\\": 100100,
+    \\"type\\": \\"PROJECT\\"
+  },
+  \\"team\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/teams/14\\",
+    \\"id\\": 14,
+    \\"name\\": \\"Team-A\\"
+  }
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Team-link cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Link with id &#39;99&#39; does not exist\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"team_links__id__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Delete an existing team-link</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#team_links__id__delete_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#team_links__id__delete_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#team_links__id__delete_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"team_links__id__delete_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"team_links__id__delete_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
+<p>Team-link has been successfully deleted</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Team-link cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Link with id &#39;99&#39; does not exist\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"team_links__id__delete_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_team_links_project__projectkey_\\" href=\\"#panel_team_links_project__projectkey_\\"><span class=\\"parent\\">/team-links</span>/project/{projectKey}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_team_links_project__projectkey_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve team-link by project</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#team_links_project__projectkey__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#team_links_project__projectkey__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#team_links_project__projectkey__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"team_links_project__projectkey__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>projectKey</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"team_links_project__projectkey__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Retrieve team-links</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of TeamLinkByScope)</em><p><strong>Items</strong>: TeamLinkByScope</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (number)</em></li><li><strong>scope</strong>: <em>required (scope)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>team</strong>: <em>required (team)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>summary</strong>: <em>(string)</em></li><li><strong>lead</strong>: <em>(lead)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>program</strong>: <em>(program)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li><li><strong>links</strong>: <em>required (links)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>members</strong>: <em>required (members)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>permissions</strong>: <em>required (permissions)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/team-links/project/PRJ-1\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/team-links/1\\",
+      \\"id\\": 1,
+      \\"scope\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/project/PRJ-1\\"
+      },
+      \\"team\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/1\\",
+        \\"id\\": 1,
+        \\"name\\": \\"Team-A\\",
+        \\"summary\\": \\"This is the A team\\",
+        \\"lead\\": {
+          \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+          \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+          \\"displayName\\": \\"John Brown\\"
+        },
+        \\"program\\": {
+          \\"self\\": \\"https://api.tempo.io/core/3/programs/42\\",
+          \\"id\\": 42,
+          \\"name\\": \\"Devs\\"
+        },
+        \\"links\\": {
+          \\"self\\": \\"https://api.tempo.io/core/3/teams/1/links\\"
+        },
+        \\"members\\": {
+          \\"self\\": \\"https://api.tempo.io/core/3/teams/1/members\\"
+        },
+        \\"permissions\\": {
+          \\"self\\": \\"https://api.tempo.io/core/3/teams/1/permissions\\"
+        }
+      }
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/team-links/3\\",
+      \\"id\\": 3,
+      \\"scope\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/project/PRJ-1\\"
+      },
+      \\"team\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/teams/2\\",
+        \\"id\\": 2,
+        \\"name\\": \\"Team-B\\",
+        \\"links\\": {
+          \\"self\\": \\"https://api.tempo.io/core/3/teams/2/links\\"
+        },
+        \\"members\\": {
+          \\"self\\": \\"https://api.tempo.io/core/3/teams/2/members\\"
+        },
+        \\"permissions\\": {
+          \\"self\\": \\"https://api.tempo.io/core/3/teams/2/permissions\\"
+        }
+      }
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"team_links_project__projectkey__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h2 class=\\"sg-h2\\" id=\\"team_memberships\\">Team - Memberships</h2>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_team_memberships\\" href=\\"#panel_team_memberships\\"><span class=\\"parent\\"></span>/team-memberships</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_team_memberships\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Creates a new membership</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#team_memberships_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#team_memberships_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#team_memberships_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"team_memberships_post_request\\">
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>teamId</strong>: <em>required (integer)</em></li>
+<li><strong>accountId</strong>: <em>required (string)</em></li>
+<li><strong>roleId</strong>: <em>(integer - default: Default team role)</em></li>
+<li><strong>commitmentPercent</strong>: <em>(integer - default: 100)</em></li>
+<li><strong>from</strong>: <em>(date-only)</em></li>
+<li><strong>to</strong>: <em>(date-only)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"teamId\\": 1,
+  \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+  \\"roleId\\": 2,
+  \\"commitmentPercent\\": 50,
+  \\"from\\": \\"2017-06-01\\",
+  \\"to\\": \\"2017-12-31\\"
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"team_memberships_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Membership has been successfully created</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>commitmentPercent</strong>: <em>required (integer)</em></li>
+<li><strong>from</strong>: <em>(date-only)</em></li>
+<li><strong>to</strong>: <em>(date-only)</em></li>
+<li><strong>role</strong>: <em>required (role)</em><ul><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>self</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>team</strong>: <em>required (team)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>member</strong>: <em>required (member)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/team-memberships/2\\",
+  \\"id\\": 2,
+  \\"commitmentPercent\\": 50,
+  \\"from\\": \\"2017-06-01\\",
+  \\"to\\": \\"2017-12-31\\",
+  \\"role\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/roles/2\\",
+    \\"id\\": 2,
+    \\"name\\": \\"Developer\\"
+  },
+  \\"team\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/teams/1\\",
+    \\"id\\": 1,
+    \\"name\\": \\"Team-A\\"
+  },
+  \\"member\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+    \\"displayName\\": \\"John Brown\\"
+  }
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Membership cannot be created for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"User is already a member of this team on this date.\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"team_memberships_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_team_memberships__id_\\" href=\\"#panel_team_memberships__id_\\"><span class=\\"parent\\">/team-memberships</span>/{id}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_team_memberships__id_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve an existing membership for the given id</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#team_memberships__id__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#team_memberships__id__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#team_memberships__id__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"team_memberships__id__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"team_memberships__id__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Membership data of the given id</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>commitmentPercent</strong>: <em>required (integer)</em></li>
+<li><strong>from</strong>: <em>(date-only)</em></li>
+<li><strong>to</strong>: <em>(date-only)</em></li>
+<li><strong>role</strong>: <em>required (role)</em><ul><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>self</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>team</strong>: <em>(team)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>member</strong>: <em>(member)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/team-memberships/2\\",
+  \\"id\\": 2,
+  \\"commitmentPercent\\": 50,
+  \\"from\\": \\"2017-06-01\\",
+  \\"to\\": \\"2017-12-31\\",
+  \\"role\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/roles/2\\",
+    \\"id\\": 2,
+    \\"name\\": \\"Developer\\"
+  },
+  \\"team\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/teams/1\\",
+    \\"id\\": 1,
+    \\"name\\": \\"Team-A\\"
+  },
+  \\"member\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+    \\"displayName\\": \\"John Brown\\"
+  }
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Membership cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Membership with id &#39;42&#39; does not exist\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"team_memberships__id__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Update an existing membership for the given id</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#team_memberships__id__put_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#team_memberships__id__put_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#team_memberships__id__put_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"team_memberships__id__put_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>roleId</strong>: <em>(integer - default: Default team role)</em></li>
+<li><strong>commitmentPercent</strong>: <em>(integer - default: 100)</em></li>
+<li><strong>from</strong>: <em>(date-only)</em></li>
+<li><strong>to</strong>: <em>(date-only)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"roleId\\": 2,
+  \\"commitmentPercent\\": 50,
+  \\"from\\": \\"2017-06-01\\",
+  \\"to\\": \\"2017-12-31\\"
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"team_memberships__id__put_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Membership has been successfully updated</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>commitmentPercent</strong>: <em>required (integer)</em></li>
+<li><strong>from</strong>: <em>(date-only)</em></li>
+<li><strong>to</strong>: <em>(date-only)</em></li>
+<li><strong>role</strong>: <em>required (role)</em><ul><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>self</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>team</strong>: <em>(team)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>member</strong>: <em>(member)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/team-memberships/2\\",
+  \\"id\\": 2,
+  \\"commitmentPercent\\": 50,
+  \\"from\\": \\"2017-06-01\\",
+  \\"to\\": \\"2017-12-31\\",
+  \\"role\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/roles/2\\",
+    \\"id\\": 2,
+    \\"name\\": \\"Developer\\"
+  },
+  \\"team\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/teams/1\\",
+    \\"id\\": 1,
+    \\"name\\": \\"Team-A\\"
+  },
+  \\"member\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+    \\"displayName\\": \\"John Brown\\"
+  }
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Membership cannot be updated for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"User is already a member of this team on this date.\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Membership cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Membership with id &#39;42&#39; does not exist\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"team_memberships__id__put_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Delete an existing membership</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#team_memberships__id__delete_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#team_memberships__id__delete_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#team_memberships__id__delete_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"team_memberships__id__delete_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"team_memberships__id__delete_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
+<p>Membership has been successfully deleted</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Membership cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Membership with id &#39;42&#39; does not exist\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"team_memberships__id__delete_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h2 class=\\"sg-h2\\" id=\\"timesheet_approvals\\">Timesheet Approvals</h2>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_timesheet_approvals_waiting\\" href=\\"#panel_timesheet_approvals_waiting\\"><span class=\\"parent\\">/timesheet-approvals</span>/waiting</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_timesheet_approvals_waiting\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve all timesheets that are awaiting my approval</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#timesheet_approvals_waiting_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#timesheet_approvals_waiting_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"timesheet_approvals_waiting_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Awaiting Timesheets</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Timesheet Approval)</em><p><strong>Items</strong>: Timesheet Approval</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>period</strong>: <em>required (period)</em><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li></ul></li><li><strong>requiredSeconds</strong>: <em>required (number)</em></li><li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li><li><strong>status</strong>: <em>required (status)</em><ul><li><strong>key</strong>: <em>required (one of OPEN, IN_REVIEW, APPROVED)</em></li><li><strong>comment</strong>: <em>(string)</em></li><li><strong>actor</strong>: <em>(actor)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>requiredSecondsAtSubmit</strong>: <em>(number)</em></li><li><strong>timeSpentSecondsAtSubmit</strong>: <em>(number)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li></ul></li><li><strong>user</strong>: <em>required (user)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>actions</strong>: <em>required (actions)</em><ul><li><strong>submit</strong>: <em>(submit)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>approve</strong>: <em>(approve)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>reject</strong>: <em>(reject)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>reopen</strong>: <em>(reopen)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li></ul></li><li><strong>worklogs</strong>: <em>required (worklogs)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/waiting\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/123456:01234567-89ab-cdef-0123-456789abcdef?from=2016-12-01&amp;to=2016-12-31\\",
+      \\"period\\": {
+        \\"from\\": \\"2016-12-01\\",
+        \\"to\\": \\"2016-12-31\\"
+      },
+      \\"requiredSeconds\\": 633600,
+      \\"timeSpentSeconds\\": 633600,
+      \\"status\\": {
+        \\"key\\": \\"IN_REVIEW\\",
+        \\"actor\\": {
+          \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+          \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+          \\"displayName\\": \\"John Brown\\"
+        },
+        \\"requiredSecondsAtSubmit\\": 633600,
+        \\"timeSpentSecondsAtSubmit\\": 633600,
+        \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\"
+      },
+      \\"user\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+        \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+        \\"displayName\\": \\"Erica Jefferson\\"
+      },
+      \\"reviewer\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+        \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+        \\"displayName\\": \\"John Brown\\"
+      },
+      \\"actions\\": {
+        \\"approve\\": {
+          \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/123456:01234567-89ab-cdef-0123-456789abcdef/approve?from=2016-12-01&amp;to=2016-12-31\\"
+        },
+        \\"reject\\": {
+          \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/123456:01234567-89ab-cdef-0123-456789abcdef/reject?from=2016-12-01&amp;to=2016-12-31\\"
+        }
+      },
+      \\"worklogs\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/worklogs/user/123456:01234567-89ab-cdef-0123-456789abcdef?from=2016-12-01&amp;to=2016-12-31\\"
+      }
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/1111aaaa2222bbbb3333cccc?from=2016-12-01&amp;to=2016-12-31\\",
+      \\"period\\": {
+        \\"from\\": \\"2016-12-01\\",
+        \\"to\\": \\"2016-12-31\\"
+      },
+      \\"requiredSeconds\\": 633600,
+      \\"timeSpentSeconds\\": 633600,
+      \\"status\\": {
+        \\"key\\": \\"IN_REVIEW\\",
+        \\"actor\\": {
+          \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+          \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+          \\"displayName\\": \\"John Brown\\"
+        },
+        \\"requiredSecondsAtSubmit\\": 633600,
+        \\"timeSpentSecondsAtSubmit\\": 633600,
+        \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\"
+      },
+      \\"user\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+        \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+        \\"displayName\\": \\"John Brown\\"
+      },
+      \\"reviewer\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+        \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+        \\"displayName\\": \\"John Brown\\"
+      },
+      \\"actions\\": {
+        \\"approve\\": {
+          \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/1111aaaa2222bbbb3333cccc/approve?from=2016-12-01&amp;to=2016-12-31\\"
+        },
+        \\"reject\\": {
+          \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/1111aaaa2222bbbb3333cccc/reject?from=2016-12-01&amp;to=2016-12-31\\"
+        }
+      },
+      \\"worklogs\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/worklogs/user/1111aaaa2222bbbb3333cccc?from=2016-12-01&amp;to=2016-12-31\\"
+      }
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"timesheet_approvals_waiting_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_timesheet_approvals_user__accountid_\\" href=\\"#panel_timesheet_approvals_user__accountid_\\"><span class=\\"parent\\">/timesheet-approvals</span>/user/{accountId}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_timesheet_approvals_user__accountid_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve the current approval for a given period</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#timesheet_approvals_user__accountid__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#timesheet_approvals_user__accountid__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#timesheet_approvals_user__accountid__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"timesheet_approvals_user__accountid__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>accountId</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>from</strong>: <em>(date-only)</em><p>Retrieve results starting with this date</p></li>
+<li><strong>to</strong>: <em>(date-only)</em><p>Retrieve results up to and including this date</p></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"timesheet_approvals_user__accountid__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>The Timesheet approval</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>period</strong>: <em>required (period)</em><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li></ul></li>
+<li><strong>requiredSeconds</strong>: <em>required (number)</em></li>
+<li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li>
+<li><strong>status</strong>: <em>required (status)</em><ul><li><strong>key</strong>: <em>required (one of OPEN, IN_REVIEW, APPROVED)</em></li><li><strong>comment</strong>: <em>(string)</em></li><li><strong>actor</strong>: <em>(actor)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>requiredSecondsAtSubmit</strong>: <em>(number)</em></li><li><strong>timeSpentSecondsAtSubmit</strong>: <em>(number)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li></ul></li>
+<li><strong>user</strong>: <em>required (user)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>actions</strong>: <em>required (actions)</em><ul><li><strong>submit</strong>: <em>(submit)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>approve</strong>: <em>(approve)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>reject</strong>: <em>(reject)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>reopen</strong>: <em>(reopen)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li></ul></li>
+<li><strong>worklogs</strong>: <em>required (worklogs)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/123456:01234567-89ab-cdef-0123-456789abcdef?from=2017-12-01&amp;to=2017-12-31\\",
+  \\"period\\": {
+    \\"from\\": \\"2017-12-01\\",
+    \\"to\\": \\"2017-12-31\\"
+  },
+  \\"requiredSeconds\\": 604800,
+  \\"timeSpentSeconds\\": 604800,
+  \\"status\\": {
+    \\"key\\": \\"APPROVED\\",
+    \\"comment\\": \\"Approved! Great job!!\\",
+    \\"actor\\": {
+      \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+      \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+      \\"displayName\\": \\"John Brown\\"
+    },
+    \\"requiredSecondsAtSubmit\\": 604800,
+    \\"timeSpentSecondsAtSubmit\\": 604800,
+    \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\"
+  },
+  \\"user\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+    \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+    \\"displayName\\": \\"Erica Jefferson\\"
+  },
+  \\"actions\\": {
+    \\"reopen\\": {
+      \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/123456:01234567-89ab-cdef-0123-456789abcdef/reopen?from=2017-12-01&amp;to=2017-12-31\\"
+    }
+  },
+  \\"worklogs\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/worklogs/user/123456:01234567-89ab-cdef-0123-456789abcdef?from=2017-12-01&amp;to=2017-12-31\\"
+  }
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"timesheet_approvals_user__accountid__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_timesheet_approvals_user__accountid__reviewers\\" href=\\"#panel_timesheet_approvals_user__accountid__reviewers\\"><span class=\\"parent\\">/timesheet-approvals/user/{accountId}</span>/reviewers</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_timesheet_approvals_user__accountid__reviewers\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Get Reviewers for a user</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#timesheet_approvals_user__accountid__reviewers_get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#timesheet_approvals_user__accountid__reviewers_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#timesheet_approvals_user__accountid__reviewers_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"timesheet_approvals_user__accountid__reviewers_get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>accountId</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"timesheet_approvals_user__accountid__reviewers_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Users with approve timesheet permission in teams where the user is a member</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of User)</em><p><strong>Items</strong>: User</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/1111aaaa2222bbbb3333cccc/reviewers\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+      \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+      \\"displayName\\": \\"John Brown\\"
+    },
+    {
+      \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+      \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+      \\"displayName\\": \\"Erica Jefferson\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"timesheet_approvals_user__accountid__reviewers_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_timesheet_approvals_user__accountid__approve\\" href=\\"#panel_timesheet_approvals_user__accountid__approve\\"><span class=\\"parent\\">/timesheet-approvals/user/{accountId}</span>/approve</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_timesheet_approvals_user__accountid__approve\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Approve Timesheet</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#timesheet_approvals_user__accountid__approve_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#timesheet_approvals_user__accountid__approve_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#timesheet_approvals_user__accountid__approve_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"timesheet_approvals_user__accountid__approve_post_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>accountId</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>from</strong>: <em>(date-only)</em><p>Starting date of the period</p></li>
+<li><strong>to</strong>: <em>(date-only)</em><p>Ending date of the period (inclusive)</p></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>comment</strong>: <em>(string)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"comment\\": \\"Approved! Great job!!\\"
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"timesheet_approvals_user__accountid__approve_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>The submitted timesheet</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>period</strong>: <em>required (period)</em><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li></ul></li>
+<li><strong>requiredSeconds</strong>: <em>required (number)</em></li>
+<li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li>
+<li><strong>status</strong>: <em>required (status)</em><ul><li><strong>key</strong>: <em>required (one of OPEN, IN_REVIEW, APPROVED)</em></li><li><strong>comment</strong>: <em>(string)</em></li><li><strong>actor</strong>: <em>(actor)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>requiredSecondsAtSubmit</strong>: <em>(number)</em></li><li><strong>timeSpentSecondsAtSubmit</strong>: <em>(number)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li></ul></li>
+<li><strong>user</strong>: <em>required (user)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>actions</strong>: <em>required (actions)</em><ul><li><strong>submit</strong>: <em>(submit)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>approve</strong>: <em>(approve)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>reject</strong>: <em>(reject)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>reopen</strong>: <em>(reopen)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li></ul></li>
+<li><strong>worklogs</strong>: <em>required (worklogs)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/123456:01234567-89ab-cdef-0123-456789abcdef?from=2017-12-01&amp;to=2017-12-31\\",
+  \\"period\\": {
+    \\"from\\": \\"2017-12-01\\",
+    \\"to\\": \\"2017-12-31\\"
+  },
+  \\"requiredSeconds\\": 604800,
+  \\"timeSpentSeconds\\": 604800,
+  \\"status\\": {
+    \\"key\\": \\"APPROVED\\",
+    \\"comment\\": \\"Approved! Great job!!\\",
+    \\"actor\\": {
+      \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+      \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+      \\"displayName\\": \\"John Brown\\"
+    },
+    \\"requiredSecondsAtSubmit\\": 604800,
+    \\"timeSpentSecondsAtSubmit\\": 604800,
+    \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\"
+  },
+  \\"user\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+    \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+    \\"displayName\\": \\"Erica Jefferson\\"
+  },
+  \\"actions\\": {
+    \\"reopen\\": {
+      \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/123456:01234567-89ab-cdef-0123-456789abcdef/reopen?from=2017-12-01&amp;to=2017-12-31\\"
+    }
+  },
+  \\"worklogs\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/worklogs/user/123456:01234567-89ab-cdef-0123-456789abcdef?from=2017-12-01&amp;to=2017-12-31\\"
+  }
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"timesheet_approvals_user__accountid__approve_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_timesheet_approvals_user__accountid__reject\\" href=\\"#panel_timesheet_approvals_user__accountid__reject\\"><span class=\\"parent\\">/timesheet-approvals/user/{accountId}</span>/reject</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_timesheet_approvals_user__accountid__reject\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Reject Timesheet</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#timesheet_approvals_user__accountid__reject_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#timesheet_approvals_user__accountid__reject_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#timesheet_approvals_user__accountid__reject_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"timesheet_approvals_user__accountid__reject_post_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>accountId</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>from</strong>: <em>(date-only)</em><p>Starting date of the period</p></li>
+<li><strong>to</strong>: <em>(date-only)</em><p>Ending date of the period (inclusive)</p></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>comment</strong>: <em>(string)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"comment\\": \\"Timesheet was rejected because you haven&#39;t fulfilled your hours, Erica\\"
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"timesheet_approvals_user__accountid__reject_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>The rejected timesheet</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>period</strong>: <em>required (period)</em><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li></ul></li>
+<li><strong>requiredSeconds</strong>: <em>required (number)</em></li>
+<li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li>
+<li><strong>status</strong>: <em>required (status)</em><ul><li><strong>key</strong>: <em>required (one of OPEN, IN_REVIEW, APPROVED)</em></li><li><strong>comment</strong>: <em>(string)</em></li><li><strong>actor</strong>: <em>(actor)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>requiredSecondsAtSubmit</strong>: <em>(number)</em></li><li><strong>timeSpentSecondsAtSubmit</strong>: <em>(number)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li></ul></li>
+<li><strong>user</strong>: <em>required (user)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>actions</strong>: <em>required (actions)</em><ul><li><strong>submit</strong>: <em>(submit)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>approve</strong>: <em>(approve)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>reject</strong>: <em>(reject)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>reopen</strong>: <em>(reopen)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li></ul></li>
+<li><strong>worklogs</strong>: <em>required (worklogs)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/123456:01234567-89ab-cdef-0123-456789abcdef?from=2017-12-01&amp;to=2017-12-31\\",
+  \\"period\\": {
+    \\"from\\": \\"2017-12-01\\",
+    \\"to\\": \\"2017-12-31\\"
+  },
+  \\"requiredSeconds\\": 604800,
+  \\"timeSpentSeconds\\": 576000,
+  \\"status\\": {
+    \\"key\\": \\"OPEN\\",
+    \\"comment\\": \\"Timesheet was rejected because you haven&#39;t fulfilled your hours, Erica\\",
+    \\"actor\\": {
+      \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+      \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+      \\"displayName\\": \\"John Brown\\"
+    },
+    \\"requiredSecondsAtSubmit\\": 604800,
+    \\"timeSpentSecondsAtSubmit\\": 576000,
+    \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\"
+  },
+  \\"user\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+    \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+    \\"displayName\\": \\"Erica Jefferson\\"
+  },
+  \\"reviewer\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+    \\"displayName\\": \\"John Brown\\"
+  },
+  \\"actions\\": {
+    \\"approve\\": {
+      \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/123456:01234567-89ab-cdef-0123-456789abcdef/approve?from=2017-12-01&amp;to=2017-12-31\\"
+    },
+    \\"reject\\": {
+      \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/123456:01234567-89ab-cdef-0123-456789abcdef/reject?from=2017-12-01&amp;to=2017-12-31\\"
+    }
+  },
+  \\"worklogs\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/worklogs/user/123456:01234567-89ab-cdef-0123-456789abcdef?from=2017-12-01&amp;to=2017-12-31\\"
+  }
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"timesheet_approvals_user__accountid__reject_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_timesheet_approvals_user__accountid__reopen\\" href=\\"#panel_timesheet_approvals_user__accountid__reopen\\"><span class=\\"parent\\">/timesheet-approvals/user/{accountId}</span>/reopen</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_timesheet_approvals_user__accountid__reopen\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Re-open Timesheet</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#timesheet_approvals_user__accountid__reopen_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#timesheet_approvals_user__accountid__reopen_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#timesheet_approvals_user__accountid__reopen_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"timesheet_approvals_user__accountid__reopen_post_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>accountId</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>from</strong>: <em>(date-only)</em><p>Starting date of the period</p></li>
+<li><strong>to</strong>: <em>(date-only)</em><p>Ending date of the period (inclusive)</p></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>comment</strong>: <em>(string)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"comment\\": \\"Timesheet was reopened so you can fix your timesheet, Erica\\"
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"timesheet_approvals_user__accountid__reopen_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>The reopened timesheet</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>period</strong>: <em>required (period)</em><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li></ul></li>
+<li><strong>requiredSeconds</strong>: <em>required (number)</em></li>
+<li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li>
+<li><strong>status</strong>: <em>required (status)</em><ul><li><strong>key</strong>: <em>required (one of OPEN, IN_REVIEW, APPROVED)</em></li><li><strong>comment</strong>: <em>(string)</em></li><li><strong>actor</strong>: <em>(actor)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>requiredSecondsAtSubmit</strong>: <em>(number)</em></li><li><strong>timeSpentSecondsAtSubmit</strong>: <em>(number)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li></ul></li>
+<li><strong>user</strong>: <em>required (user)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>actions</strong>: <em>required (actions)</em><ul><li><strong>submit</strong>: <em>(submit)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>approve</strong>: <em>(approve)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>reject</strong>: <em>(reject)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>reopen</strong>: <em>(reopen)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li></ul></li>
+<li><strong>worklogs</strong>: <em>required (worklogs)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/123456:01234567-89ab-cdef-0123-456789abcdef?from=2017-12-01&amp;to=2017-12-31\\",
+  \\"period\\": {
+    \\"from\\": \\"2017-12-01\\",
+    \\"to\\": \\"2017-12-31\\"
+  },
+  \\"requiredSeconds\\": 604800,
+  \\"timeSpentSeconds\\": 576000,
+  \\"status\\": {
+    \\"key\\": \\"OPEN\\",
+    \\"comment\\": \\"Timesheet was reopened so you can fix your timesheet, Erica\\",
+    \\"actor\\": {
+      \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+      \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+      \\"displayName\\": \\"John Brown\\"
+    },
+    \\"requiredSecondsAtSubmit\\": 604800,
+    \\"timeSpentSecondsAtSubmit\\": 576000,
+    \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\"
+  },
+  \\"user\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+    \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+    \\"displayName\\": \\"Erica Jefferson\\"
+  },
+  \\"reviewer\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+    \\"displayName\\": \\"John Brown\\"
+  },
+  \\"actions\\": {
+    \\"approve\\": {
+      \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/123456:01234567-89ab-cdef-0123-456789abcdef/approve?from=2017-12-01&amp;to=2017-12-31\\"
+    },
+    \\"reject\\": {
+      \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/123456:01234567-89ab-cdef-0123-456789abcdef/reject?from=2017-12-01&amp;to=2017-12-31\\"
+    }
+  },
+  \\"worklogs\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/worklogs/user/123456:01234567-89ab-cdef-0123-456789abcdef?from=2017-12-01&amp;to=2017-12-31\\"
+  }
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"timesheet_approvals_user__accountid__reopen_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_timesheet_approvals_user__accountid__submit\\" href=\\"#panel_timesheet_approvals_user__accountid__submit\\"><span class=\\"parent\\">/timesheet-approvals/user/{accountId}</span>/submit</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_timesheet_approvals_user__accountid__submit\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Submit Timesheet for approvals</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#timesheet_approvals_user__accountid__submit_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#timesheet_approvals_user__accountid__submit_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#timesheet_approvals_user__accountid__submit_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"timesheet_approvals_user__accountid__submit_post_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>accountId</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>from</strong>: <em>(date-only)</em><p>Starting date of the period</p></li>
+<li><strong>to</strong>: <em>(date-only)</em><p>Ending date of the period (inclusive)</p></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>comment</strong>: <em>(string)</em></li>
+<li><strong>reviewerAccountId</strong>: <em>required (string)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"comment\\": \\"Please review my timesheet, John\\",
+  \\"reviewerAccountId\\": \\"1111aaaa2222bbbb3333cccc\\"
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"timesheet_approvals_user__accountid__submit_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>The submitted timesheet</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>period</strong>: <em>required (period)</em><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li></ul></li>
+<li><strong>requiredSeconds</strong>: <em>required (number)</em></li>
+<li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li>
+<li><strong>status</strong>: <em>required (status)</em><ul><li><strong>key</strong>: <em>required (one of OPEN, IN_REVIEW, APPROVED)</em></li><li><strong>comment</strong>: <em>(string)</em></li><li><strong>actor</strong>: <em>(actor)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>requiredSecondsAtSubmit</strong>: <em>(number)</em></li><li><strong>timeSpentSecondsAtSubmit</strong>: <em>(number)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li></ul></li>
+<li><strong>user</strong>: <em>required (user)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>actions</strong>: <em>required (actions)</em><ul><li><strong>submit</strong>: <em>(submit)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>approve</strong>: <em>(approve)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>reject</strong>: <em>(reject)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>reopen</strong>: <em>(reopen)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li></ul></li>
+<li><strong>worklogs</strong>: <em>required (worklogs)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/123456:01234567-89ab-cdef-0123-456789abcdef?from=2017-12-01&amp;to=2017-12-31\\",
+  \\"period\\": {
+    \\"from\\": \\"2017-12-01\\",
+    \\"to\\": \\"2017-12-31\\"
+  },
+  \\"requiredSeconds\\": 604800,
+  \\"timeSpentSeconds\\": 604800,
+  \\"status\\": {
+    \\"key\\": \\"IN_REVIEW\\",
+    \\"comment\\": \\"Please review my timesheet, John\\",
+    \\"actor\\": {
+      \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+      \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+      \\"displayName\\": \\"Erica Jefferson\\"
+    },
+    \\"requiredSecondsAtSubmit\\": 604800,
+    \\"timeSpentSecondsAtSubmit\\": 604800,
+    \\"updatedAt\\": \\"2017-02-23T15:07:00Z\\"
+  },
+  \\"user\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+    \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+    \\"displayName\\": \\"Erica Jefferson\\"
+  },
+  \\"reviewer\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+    \\"displayName\\": \\"John Brown\\"
+  },
+  \\"actions\\": {
+    \\"approve\\": {
+      \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/123456:01234567-89ab-cdef-0123-456789abcdef/approve?from=2017-12-01&amp;to=2017-12-31\\"
+    },
+    \\"reject\\": {
+      \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/123456:01234567-89ab-cdef-0123-456789abcdef/reject?from=2017-12-01&amp;to=2017-12-31\\"
+    }
+  },
+  \\"worklogs\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/worklogs/user/123456:01234567-89ab-cdef-0123-456789abcdef?from=2017-12-01&amp;to=2017-12-31\\"
+  }
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"timesheet_approvals_user__accountid__submit_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_timesheet_approvals_team__teamid_\\" href=\\"#panel_timesheet_approvals_team__teamid_\\"><span class=\\"parent\\">/timesheet-approvals</span>/team/{teamId}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_timesheet_approvals_team__teamid_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve the current approval for a team in a given period</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#timesheet_approvals_team__teamid__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#timesheet_approvals_team__teamid__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#timesheet_approvals_team__teamid__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"timesheet_approvals_team__teamid__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>teamId</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>from</strong>: <em>(date-only)</em><p>Retrieve results starting with this date</p></li>
+<li><strong>to</strong>: <em>(date-only)</em><p>Retrieve results up to and including this date</p></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"timesheet_approvals_team__teamid__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>The Timesheet approval</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Timesheet Approval)</em><p><strong>Items</strong>: Timesheet Approval</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>period</strong>: <em>required (period)</em><ul><li><strong>from</strong>: <em>required (date-only)</em></li><li><strong>to</strong>: <em>required (date-only)</em></li></ul></li><li><strong>requiredSeconds</strong>: <em>required (number)</em></li><li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li><li><strong>status</strong>: <em>required (status)</em><ul><li><strong>key</strong>: <em>required (one of OPEN, IN_REVIEW, APPROVED)</em></li><li><strong>comment</strong>: <em>(string)</em></li><li><strong>actor</strong>: <em>(actor)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>requiredSecondsAtSubmit</strong>: <em>(number)</em></li><li><strong>timeSpentSecondsAtSubmit</strong>: <em>(number)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li></ul></li><li><strong>user</strong>: <em>required (user)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>actions</strong>: <em>required (actions)</em><ul><li><strong>submit</strong>: <em>(submit)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>approve</strong>: <em>(approve)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>reject</strong>: <em>(reject)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li><li><strong>reopen</strong>: <em>(reopen)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li></ul></li><li><strong>worklogs</strong>: <em>required (worklogs)</em><ul><li><strong>self</strong>: <em>required (string)</em></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/team/1?from=2017-12-01&amp;to=2017-12-31\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/123456:01234567-89ab-cdef-0123-456789abcdef?from=2017-12-01&amp;to=2017-12-31\\",
+      \\"period\\": {
+        \\"from\\": \\"2017-12-01\\",
+        \\"to\\": \\"2017-12-31\\"
+      },
+      \\"requiredSeconds\\": 604800,
+      \\"timeSpentSeconds\\": 360000,
+      \\"status\\": {
+        \\"key\\": \\"OPEN\\",
+        \\"comment\\": \\"Timesheet was rejected because you haven&#39;t fulfilled your hours, Erica\\",
+        \\"actor\\": {
+          \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+          \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+          \\"displayName\\": \\"John Brown\\"
+        },
+        \\"requiredSecondsAtSubmit\\": 604800,
+        \\"timeSpentSecondsAtSubmit\\": 0,
+        \\"updatedAt\\": \\"2018-01-03T15:07:00Z\\"
+      },
+      \\"user\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=123456:01234567-89ab-cdef-0123-456789abcdef\\",
+        \\"accountId\\": \\"123456:01234567-89ab-cdef-0123-456789abcdef\\",
+        \\"displayName\\": \\"Erica Jefferson\\"
+      },
+      \\"actions\\": {
+        \\"submit\\": {
+          \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/123456:01234567-89ab-cdef-0123-456789abcdef/submit?from=2017-12-01&amp;to=2017-12-31\\"
+        }
+      },
+      \\"worklogs\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/worklogs/user/123456:01234567-89ab-cdef-0123-456789abcdef?from=2017-12-01&amp;to=2017-12-31\\"
+      }
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/aabbccddeeff001122334455?from=2017-12-01&amp;to=2017-12-31\\",
+      \\"period\\": {
+        \\"from\\": \\"2017-12-01\\",
+        \\"to\\": \\"2017-12-31\\"
+      },
+      \\"requiredSeconds\\": 604800,
+      \\"timeSpentSeconds\\": 604800,
+      \\"status\\": {
+        \\"key\\": \\"APPROVED\\",
+        \\"comment\\": \\"Approved! Great job!!\\",
+        \\"actor\\": {
+          \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+          \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+          \\"displayName\\": \\"John Brown\\"
+        },
+        \\"requiredSecondsAtSubmit\\": 604800,
+        \\"timeSpentSecondsAtSubmit\\": 604800,
+        \\"updatedAt\\": \\"2018-01-03T15:07:00Z\\"
+      },
+      \\"user\\": {
+        \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=aabbccddeeff001122334455\\",
+        \\"accountId\\": \\"aabbccddeeff001122334455\\",
+        \\"displayName\\": \\"Judy Simpson\\"
+      },
+      \\"actions\\": {
+        \\"reopen\\": {
+          \\"self\\": \\"https://api.tempo.io/core/3/timesheet-approvals/user/aabbccddeeff001122334455/reopen?from=2017-12-01&amp;to=2017-12-31\\"
+        }
+      },
+      \\"worklogs\\": {
+        \\"self\\": \\"https://api.tempo.io/core/3/worklogs/user/aabbccddeeff001122334455?from=2017-12-01&amp;to=2017-12-31\\"
+      }
+    }
+
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Team cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Team not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"timesheet_approvals_team__teamid__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h2 class=\\"sg-h2\\" id=\\"user_schedule\\">User Schedule</h2>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_user_schedule\\" href=\\"#panel_user_schedule\\"><span class=\\"parent\\"></span>/user-schedule</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_user_schedule\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve user-schedule of the logged-in user</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#user_schedule_get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#user_schedule_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#user_schedule_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"user_schedule_get_request\\">
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>from</strong>: <em>required (date-only)</em><p>Retrieve results starting with this date</p></li>
+<li><strong>to</strong>: <em>required (date-only)</em><p>Retrieve results up to and including this date</p></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"user_schedule_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>List of day-schedules</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Day schedule)</em><p><strong>Items</strong>: Day schedule</p><div class=\\"items\\"><ul><li><strong>date</strong>: <em>required (date-only)</em></li><li><strong>requiredSeconds</strong>: <em>required (number)</em></li><li><strong>type</strong>: <em>required (one of WORKING_DAY, NON_WORKING_DAY, HOLIDAY, HOLIDAY_AND_NON_WORKING_DAY)</em></li><li><strong>holiday</strong>: <em>(holiday)</em><ul><li><strong>name</strong>: <em>required (string)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>durationSeconds</strong>: <em>required (number)</em></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/user-schedule?from=2017-12-23&amp;to=2017-12-27\\",
+  \\"metadata\\": {
+    \\"count\\": 5
+  },
+  \\"results\\": [
+    {
+      \\"date\\": \\"2017-12-23\\",
+      \\"requiredSeconds\\": 0,
+      \\"type\\": \\"NON_WORKING_DAY\\"
+    },
+    {
+      \\"date\\": \\"2017-12-24\\",
+      \\"requiredSeconds\\": 0,
+      \\"type\\": \\"HOLIDAY_AND_NON_WORKING_DAY\\",
+      \\"holiday\\": {
+        \\"name\\": \\"Christmas Eve\\",
+        \\"description\\": \\"Twas the night before Christmas\\",
+        \\"durationSeconds\\": 14400
+      }
+    },
+    {
+      \\"date\\": \\"2017-12-25\\",
+      \\"requiredSeconds\\": 0,
+      \\"type\\": \\"HOLIDAY\\",
+      \\"holiday\\": {
+        \\"name\\": \\"Christmas Day\\",
+        \\"durationSeconds\\": 28800
+      }
+    },
+    {
+      \\"date\\": \\"2017-12-26\\",
+      \\"requiredSeconds\\": 0,
+      \\"type\\": \\"HOLIDAY\\",
+      \\"holiday\\": {
+        \\"name\\": \\"Boxing Day\\",
+        \\"durationSeconds\\": 28800
+      }
+    },
+    {
+      \\"date\\": \\"2017-12-27\\",
+      \\"requiredSeconds\\": 28800,
+      \\"type\\": \\"WORKING_DAY\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+</div>
+<div class=\\"tab-pane\\" id=\\"user_schedule_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_user_schedule__accountid_\\" href=\\"#panel_user_schedule__accountid_\\"><span class=\\"parent\\">/user-schedule</span>/{accountId}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_user_schedule__accountid_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"resource-description\\">
+<p>Retrieve user-schedule of the given user</p>
+</div>
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve user-schedule</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#user_schedule__accountid__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#user_schedule__accountid__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#user_schedule__accountid__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"user_schedule__accountid__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>accountId</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>from</strong>: <em>required (date-only)</em><p>Retrieve results starting with this date</p></li>
+<li><strong>to</strong>: <em>required (date-only)</em><p>Retrieve results up to and including this date</p></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"user_schedule__accountid__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>List of day-schedules</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Day schedule)</em><p><strong>Items</strong>: Day schedule</p><div class=\\"items\\"><ul><li><strong>date</strong>: <em>required (date-only)</em></li><li><strong>requiredSeconds</strong>: <em>required (number)</em></li><li><strong>type</strong>: <em>required (one of WORKING_DAY, NON_WORKING_DAY, HOLIDAY, HOLIDAY_AND_NON_WORKING_DAY)</em></li><li><strong>holiday</strong>: <em>(holiday)</em><ul><li><strong>name</strong>: <em>required (string)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>durationSeconds</strong>: <em>required (number)</em></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/user-schedule/1111aaaa2222bbbb3333cccc?from=2017-12-23&amp;to=2017-12-27\\",
+  \\"metadata\\": {
+    \\"count\\": 5
+  },
+  \\"results\\": [
+    {
+      \\"date\\": \\"2017-12-23\\",
+      \\"requiredSeconds\\": 0,
+      \\"type\\": \\"NON_WORKING_DAY\\"
+    },
+    {
+      \\"date\\": \\"2017-12-24\\",
+      \\"requiredSeconds\\": 0,
+      \\"type\\": \\"HOLIDAY_AND_NON_WORKING_DAY\\",
+      \\"holiday\\": {
+        \\"name\\": \\"Christmas Eve\\",
+        \\"description\\": \\"Twas the night before Christmas\\",
+        \\"durationSeconds\\": 14400
+      }
+    },
+    {
+      \\"date\\": \\"2017-12-25\\",
+      \\"requiredSeconds\\": 0,
+      \\"type\\": \\"HOLIDAY\\",
+      \\"holiday\\": {
+        \\"name\\": \\"Christmas Day\\",
+        \\"durationSeconds\\": 28800
+      }
+    },
+    {
+      \\"date\\": \\"2017-12-26\\",
+      \\"requiredSeconds\\": 0,
+      \\"type\\": \\"HOLIDAY\\",
+      \\"holiday\\": {
+        \\"name\\": \\"Boxing Day\\",
+        \\"durationSeconds\\": 28800
+      }
+    },
+    {
+      \\"date\\": \\"2017-12-27\\",
+      \\"requiredSeconds\\": 28800,
+      \\"type\\": \\"WORKING_DAY\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+</div>
+<div class=\\"tab-pane\\" id=\\"user_schedule__accountid__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h2 class=\\"sg-h2\\" id=\\"work_attributes\\">Work Attributes</h2>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_work_attributes\\" href=\\"#panel_work_attributes\\"><span class=\\"parent\\"></span>/work-attributes</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_work_attributes\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve all work attributes</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#work_attributes_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#work_attributes_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"work_attributes_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>List of all work attributes</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Work Attribute)</em><p><strong>Items</strong>: Work Attribute</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li><li><strong>required</strong>: <em>required (boolean - default: false)</em></li><li><strong>values</strong>: <em>(array of )</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/work-attributes\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/work-attributes/_COLOR_\\",
+      \\"key\\": \\"_COLOR_\\",
+      \\"name\\": \\"Color\\",
+      \\"type\\": \\"STATIC_LIST\\",
+      \\"required\\": false,
+      \\"values\\": [
+        \\"red\\",
+        \\"green\\",
+        \\"blue\\",
+        \\"yellow\\",
+        \\"pink\\"
+      ]
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/work-attributes/_EXTERNALREF_\\",
+      \\"key\\": \\"_EXTERNALREF_\\",
+      \\"name\\": \\"External Ref.\\",
+      \\"type\\": \\"INPUT_FIELD\\",
+      \\"required\\": true
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"work_attributes_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Create a work attribute</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#work_attributes_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#work_attributes_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#work_attributes_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"work_attributes_post_request\\">
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>type</strong>: <em>required (one of ACCOUNT, CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li>
+<li><strong>required</strong>: <em>required (boolean - default: false)</em></li>
+<li><strong>values</strong>: <em>(array of )</em><p>When manipulating a work attribute of type \\"STATIC_LIST\\", set the list item values in this property. Otherwise, leave it empty.</p></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"key\\": \\"_COLOR_\\",
+  \\"name\\": \\"Color\\",
+  \\"type\\": \\"STATIC_LIST\\",
+  \\"required\\": false,
+  \\"values\\": [
+    \\"red\\",
+    \\"green\\",
+    \\"blue\\",
+    \\"yellow\\",
+    \\"pink\\"
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"work_attributes_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Work attribute has been successfully created</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li>
+<li><strong>required</strong>: <em>required (boolean - default: false)</em></li>
+<li><strong>values</strong>: <em>(array of )</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/work-attributes/_COLOR_\\",
+  \\"key\\": \\"_COLOR_\\",
+  \\"name\\": \\"Color\\",
+  \\"type\\": \\"STATIC_LIST\\",
+  \\"required\\": false,
+  \\"values\\": [
+    \\"red\\",
+    \\"green\\",
+    \\"blue\\",
+    \\"yellow\\",
+    \\"pink\\"
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Work attribute cannot be created for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Missing work attribute name\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"work_attributes_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_work_attributes__key_\\" href=\\"#panel_work_attributes__key_\\"><span class=\\"parent\\">/work-attributes</span>/{key}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_work_attributes__key_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve an existing work attribute for the given key</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#work_attributes__key__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#work_attributes__key__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#work_attributes__key__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"work_attributes__key__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"work_attributes__key__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Work attribute data of the given key</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li>
+<li><strong>required</strong>: <em>required (boolean - default: false)</em></li>
+<li><strong>values</strong>: <em>(array of )</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/work-attributes/_COLOR_\\",
+  \\"key\\": \\"_COLOR_\\",
+  \\"name\\": \\"Color\\",
+  \\"type\\": \\"STATIC_LIST\\",
+  \\"required\\": false,
+  \\"values\\": [
+    \\"red\\",
+    \\"green\\",
+    \\"blue\\",
+    \\"yellow\\",
+    \\"pink\\"
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Work attribute cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"A work attribute with key &#39;_COLOR_&#39; does not exist\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"work_attributes__key__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Update an existing work attribute for the given key</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#work_attributes__key__put_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#work_attributes__key__put_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#work_attributes__key__put_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"work_attributes__key__put_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>type</strong>: <em>required (one of ACCOUNT, CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li>
+<li><strong>required</strong>: <em>required (boolean - default: false)</em></li>
+<li><strong>values</strong>: <em>(array of )</em><p>When manipulating a work attribute of type \\"STATIC_LIST\\", set the list item values in this property. Otherwise, leave it empty.</p></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"key\\": \\"_COLOR_\\",
+  \\"name\\": \\"Color\\",
+  \\"type\\": \\"STATIC_LIST\\",
+  \\"required\\": false,
+  \\"values\\": [
+    \\"red\\",
+    \\"green\\",
+    \\"blue\\",
+    \\"yellow\\",
+    \\"pink\\"
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"work_attributes__key__put_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Work attribute data of the given key</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li>
+<li><strong>required</strong>: <em>required (boolean - default: false)</em></li>
+<li><strong>values</strong>: <em>(array of )</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/work-attributes/_COLOR_\\",
+  \\"key\\": \\"_COLOR_\\",
+  \\"name\\": \\"Color\\",
+  \\"type\\": \\"STATIC_LIST\\",
+  \\"required\\": false,
+  \\"values\\": [
+    \\"red\\",
+    \\"green\\",
+    \\"blue\\",
+    \\"yellow\\",
+    \\"pink\\"
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Work attribute cannot be updated for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Missing work attribute name\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Work attribute cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"A work attribute with key &#39;_COLOR_&#39; does not exist\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"work_attributes__key__put_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Update an existing work attribute for the given key</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#work_attributes__key__put_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#work_attributes__key__put_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#work_attributes__key__put_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"work_attributes__key__put_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>type</strong>: <em>required (one of ACCOUNT, CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li>
+<li><strong>required</strong>: <em>required (boolean - default: false)</em></li>
+<li><strong>values</strong>: <em>(array of )</em><p>When manipulating a work attribute of type \\"STATIC_LIST\\", set the list item values in this property. Otherwise, leave it empty.</p></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"key\\": \\"_COLOR_\\",
+  \\"name\\": \\"Color\\",
+  \\"type\\": \\"STATIC_LIST\\",
+  \\"required\\": false,
+  \\"values\\": [
+    \\"red\\",
+    \\"green\\",
+    \\"blue\\",
+    \\"yellow\\",
+    \\"pink\\"
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"work_attributes__key__put_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Work attribute data of the given key</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li>
+<li><strong>required</strong>: <em>required (boolean - default: false)</em></li>
+<li><strong>values</strong>: <em>(array of )</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/work-attributes/_COLOR_\\",
+  \\"key\\": \\"_COLOR_\\",
+  \\"name\\": \\"Color\\",
+  \\"type\\": \\"STATIC_LIST\\",
+  \\"required\\": false,
+  \\"values\\": [
+    \\"red\\",
+    \\"green\\",
+    \\"blue\\",
+    \\"yellow\\",
+    \\"pink\\"
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Work attribute cannot be updated for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Missing work attribute name\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Work attribute cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"A work attribute with key &#39;_COLOR_&#39; does not exist\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"work_attributes__key__put_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Delete an existing work attribute for the given key</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#work_attributes__key__delete_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#work_attributes__key__delete_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#work_attributes__key__delete_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"work_attributes__key__delete_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"work_attributes__key__delete_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
+<p>Worklog has been successfully deleted</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Work attribute cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"A work attribute with key &#39;_COLOR_&#39; does not exist\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"work_attributes__key__delete_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Delete an existing work attribute for the given key</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#work_attributes__key__delete_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#work_attributes__key__delete_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#work_attributes__key__delete_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"work_attributes__key__delete_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"work_attributes__key__delete_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
+<p>Worklog has been successfully deleted</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Work attribute cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"A work attribute with key &#39;_COLOR_&#39; does not exist\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"work_attributes__key__delete_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h2 class=\\"sg-h2\\" id=\\"workload_schemes\\">Workload Schemes</h2>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_workload_schemes\\" href=\\"#panel_workload_schemes\\"><span class=\\"parent\\"></span>/workload-schemes</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_workload_schemes\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve all workload schemes</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#workload_schemes_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#workload_schemes_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"workload_schemes_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>List of all workload schemes</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Workload scheme)</em><p><strong>Items</strong>: Workload scheme</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>id</strong>: <em>required (integer)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>description</strong>: <em>(string)</em></li><li><strong>defaultScheme</strong>: <em>required (boolean)</em></li><li><strong>memberCount</strong>: <em>required (number)</em></li><li><strong>days</strong>: <em>required (array of Workload scheme day)</em><p><strong>Items</strong>: Workload scheme day</p><div class=\\"items\\"><ul><li><strong>day</strong>: <em>required (string)</em></li><li><strong>requiredSeconds</strong>: <em>required (number)</em></li></ul></div></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/workload-schemes\\",
+  \\"metadata\\": {
+    \\"count\\": 2
+  },
+  \\"results\\": [
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/workload-schemes/123\\",
+      \\"id\\": 123,
+      \\"name\\": \\"Default Workload Scheme\\",
+      \\"description\\": \\"Employees are part of this scheme by default\\",
+      \\"defaultScheme\\": true,
+      \\"memberCount\\": 33,
+      \\"days\\": [
+        {
+          \\"day\\": \\"MONDAY\\",
+          \\"requiredSeconds\\": 28800
+        },
+        {
+          \\"day\\": \\"TUESDAY\\",
+          \\"requiredSeconds\\": 28800
+        },
+        {
+          \\"day\\": \\"WEDNESDAY\\",
+          \\"requiredSeconds\\": 28800
+        },
+        {
+          \\"day\\": \\"THURSDAY\\",
+          \\"requiredSeconds\\": 28800
+        },
+        {
+          \\"day\\": \\"FRIDAY\\",
+          \\"requiredSeconds\\": 28800
+        },
+        {
+          \\"day\\": \\"SATURDAY\\",
+          \\"requiredSeconds\\": 0
+        },
+        {
+          \\"day\\": \\"SUNDAY\\",
+          \\"requiredSeconds\\": 0
+        }
+      ]
+    },
+    {
+      \\"self\\": \\"https://api.tempo.io/core/3/workload-schemes/456\\",
+      \\"id\\": 456,
+      \\"name\\": \\"Part-time Workload Scheme\\",
+      \\"description\\": \\"Employees working 50%\\",
+      \\"defaultScheme\\": false,
+      \\"memberCount\\": 7,
+      \\"days\\": [
+        {
+          \\"day\\": \\"MONDAY\\",
+          \\"requiredSeconds\\": 14400
+        },
+        {
+          \\"day\\": \\"TUESDAY\\",
+          \\"requiredSeconds\\": 14400
+        },
+        {
+          \\"day\\": \\"WEDNESDAY\\",
+          \\"requiredSeconds\\": 14400
+        },
+        {
+          \\"day\\": \\"THURSDAY\\",
+          \\"requiredSeconds\\": 14400
+        },
+        {
+          \\"day\\": \\"FRIDAY\\",
+          \\"requiredSeconds\\": 14400
+        },
+        {
+          \\"day\\": \\"SATURDAY\\",
+          \\"requiredSeconds\\": 0
+        },
+        {
+          \\"day\\": \\"SUNDAY\\",
+          \\"requiredSeconds\\": 0
+        }
+      ]
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"workload_schemes_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Create a workload scheme</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#workload_schemes_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#workload_schemes_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#workload_schemes_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"workload_schemes_post_request\\">
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>days</strong>: <em>required (array of Workload scheme day)</em><p><strong>Items</strong>: Workload scheme day</p><div class=\\"items\\"><ul><li><strong>day</strong>: <em>required (string)</em></li><li><strong>requiredSeconds</strong>: <em>required (number)</em></li></ul></div></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"workload_schemes_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Workload scheme data of the scheme that was created</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>defaultScheme</strong>: <em>required (boolean)</em></li>
+<li><strong>memberCount</strong>: <em>required (number)</em></li>
+<li><strong>days</strong>: <em>required (array of Workload scheme day)</em><p><strong>Items</strong>: Workload scheme day</p><div class=\\"items\\"><ul><li><strong>day</strong>: <em>required (string)</em></li><li><strong>requiredSeconds</strong>: <em>required (number)</em></li></ul></div></li>
+</ul>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Workload scheme cannot be created for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"You must specify a scheme name\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"workload_schemes_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_workload_schemes__id_\\" href=\\"#panel_workload_schemes__id_\\"><span class=\\"parent\\">/workload-schemes</span>/{id}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_workload_schemes__id_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve an existing workload scheme for the given id</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#workload_schemes__id__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#workload_schemes__id__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#workload_schemes__id__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"workload_schemes__id__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"workload_schemes__id__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Workload scheme data of the scheme that matches provided id</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>defaultScheme</strong>: <em>required (boolean)</em></li>
+<li><strong>memberCount</strong>: <em>required (number)</em></li>
+<li><strong>days</strong>: <em>required (array of Workload scheme day)</em><p><strong>Items</strong>: Workload scheme day</p><div class=\\"items\\"><ul><li><strong>day</strong>: <em>required (string)</em></li><li><strong>requiredSeconds</strong>: <em>required (number)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/workload-schemes/123\\",
+  \\"id\\": 123,
+  \\"name\\": \\"Default Workload Scheme\\",
+  \\"description\\": \\"Employees are part of this scheme by default\\",
+  \\"defaultScheme\\": true,
+  \\"memberCount\\": 33,
+  \\"days\\": [
+    {
+      \\"day\\": \\"MONDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"TUESDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"WEDNESDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"THURSDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"FRIDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"SATURDAY\\",
+      \\"requiredSeconds\\": 0
+    },
+    {
+      \\"day\\": \\"SUNDAY\\",
+      \\"requiredSeconds\\": 0
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"workload_schemes__id__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Update a workload scheme for the given id</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#workload_schemes__id__put_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#workload_schemes__id__put_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#workload_schemes__id__put_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"workload_schemes__id__put_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>days</strong>: <em>required (array of Workload scheme day)</em><p><strong>Items</strong>: Workload scheme day</p><div class=\\"items\\"><ul><li><strong>day</strong>: <em>required (string)</em></li><li><strong>requiredSeconds</strong>: <em>required (number)</em></li></ul></div></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"workload_schemes__id__put_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Workload scheme has been successfully updated</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>defaultScheme</strong>: <em>required (boolean)</em></li>
+<li><strong>memberCount</strong>: <em>required (number)</em></li>
+<li><strong>days</strong>: <em>required (array of Workload scheme day)</em><p><strong>Items</strong>: Workload scheme day</p><div class=\\"items\\"><ul><li><strong>day</strong>: <em>required (string)</em></li><li><strong>requiredSeconds</strong>: <em>required (number)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/workload-schemes/123\\",
+  \\"id\\": 123,
+  \\"name\\": \\"Default Workload Scheme\\",
+  \\"description\\": \\"Employees are part of this scheme by default\\",
+  \\"defaultScheme\\": true,
+  \\"memberCount\\": 33,
+  \\"days\\": [
+    {
+      \\"day\\": \\"MONDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"TUESDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"WEDNESDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"THURSDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"FRIDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"SATURDAY\\",
+      \\"requiredSeconds\\": 0
+    },
+    {
+      \\"day\\": \\"SUNDAY\\",
+      \\"requiredSeconds\\": 0
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Workload scheme cannot be updated for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"You must specify a scheme name\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"workload_schemes__id__put_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Delete a workload scheme for the given id</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#workload_schemes__id__delete_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#workload_schemes__id__delete_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#workload_schemes__id__delete_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"workload_schemes__id__delete_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"workload_schemes__id__delete_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
+<p>Workload scheme been successfully deleted</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"workload_schemes__id__delete_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_workload_schemes__id__default\\" href=\\"#panel_workload_schemes__id__default\\"><span class=\\"parent\\">/workload-schemes/{id}</span>/default</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_workload_schemes__id__default\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Set the default workload scheme</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#workload_schemes__id__default_put_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#workload_schemes__id__default_put_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#workload_schemes__id__default_put_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"workload_schemes__id__default_put_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"workload_schemes__id__default_put_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>The Workload scheme has been successfully set as default</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>defaultScheme</strong>: <em>required (boolean)</em></li>
+<li><strong>memberCount</strong>: <em>required (number)</em></li>
+<li><strong>days</strong>: <em>required (array of Workload scheme day)</em><p><strong>Items</strong>: Workload scheme day</p><div class=\\"items\\"><ul><li><strong>day</strong>: <em>required (string)</em></li><li><strong>requiredSeconds</strong>: <em>required (number)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/workload-schemes/123\\",
+  \\"id\\": 123,
+  \\"name\\": \\"Default Workload Scheme\\",
+  \\"description\\": \\"Employees are part of this scheme by default\\",
+  \\"defaultScheme\\": true,
+  \\"memberCount\\": 33,
+  \\"days\\": [
+    {
+      \\"day\\": \\"MONDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"TUESDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"WEDNESDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"THURSDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"FRIDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"SATURDAY\\",
+      \\"requiredSeconds\\": 0
+    },
+    {
+      \\"day\\": \\"SUNDAY\\",
+      \\"requiredSeconds\\": 0
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Workload scheme cannot be found in the system</p>
+</div>
+<div class=\\"tab-pane\\" id=\\"workload_schemes__id__default_put_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_workload_schemes__id__members\\" href=\\"#panel_workload_schemes__id__members\\"><span class=\\"parent\\">/workload-schemes/{id}</span>/members</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_workload_schemes__id__members\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Get members in a workload scheme</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#workload_schemes__id__members_get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#workload_schemes__id__members_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#workload_schemes__id__members_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"workload_schemes__id__members_get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"workload_schemes__id__members_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Members in the workload scheme</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>offset</strong>: <em>required (integer - default: 0)</em></li><li><strong>limit</strong>: <em>required (integer - default: 50 - maximum: 1000)</em></li><li><strong>next</strong>: <em>(string)</em></li><li><strong>previous</strong>: <em>(string)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of User)</em><p><strong>Items</strong>: User</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/workload-schemes/1/members&amp;offset=0&amp;limit=50\\",
+  \\"metadata\\": {
+    \\"count\\": 18,
+    \\"offset\\": 0,
+    \\"limit\\": 50
+  },
+  \\"results\\": [
+    // skipped
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Workload scheme cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Workload scheme not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"workload_schemes__id__members_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Set user workload scheme membership</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#workload_schemes__id__members_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#workload_schemes__id__members_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#workload_schemes__id__members_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"workload_schemes__id__members_post_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>id</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>accountIds</strong>: <em>required (array of )</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"workload_schemes__id__members_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
+<p>Users have been successfully added to the workload scheme</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Workload scheme membershop cannot be updated for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"User is invalid\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Workload scheme cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Workload scheme not found\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"workload_schemes__id__members_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_workload_schemes_users__accountid_\\" href=\\"#panel_workload_schemes_users__accountid_\\"><span class=\\"parent\\">/workload-schemes</span>/users/{accountId}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_workload_schemes_users__accountid_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Get user scheme</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#workload_schemes_users__accountid__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#workload_schemes_users__accountid__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#workload_schemes_users__accountid__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"workload_schemes_users__accountid__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>accountId</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"workload_schemes_users__accountid__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>The user workload scheme</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>id</strong>: <em>required (integer)</em></li>
+<li><strong>name</strong>: <em>required (string)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>defaultScheme</strong>: <em>required (boolean)</em></li>
+<li><strong>memberCount</strong>: <em>required (number)</em></li>
+<li><strong>days</strong>: <em>required (array of Workload scheme day)</em><p><strong>Items</strong>: Workload scheme day</p><div class=\\"items\\"><ul><li><strong>day</strong>: <em>required (string)</em></li><li><strong>requiredSeconds</strong>: <em>required (number)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/workload-schemes/123\\",
+  \\"id\\": 123,
+  \\"name\\": \\"Default Workload Scheme\\",
+  \\"description\\": \\"Employees are part of this scheme by default\\",
+  \\"defaultScheme\\": true,
+  \\"memberCount\\": 33,
+  \\"days\\": [
+    {
+      \\"day\\": \\"MONDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"TUESDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"WEDNESDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"THURSDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"FRIDAY\\",
+      \\"requiredSeconds\\": 28800
+    },
+    {
+      \\"day\\": \\"SATURDAY\\",
+      \\"requiredSeconds\\": 0
+    },
+    {
+      \\"day\\": \\"SUNDAY\\",
+      \\"requiredSeconds\\": 0
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"workload_schemes_users__accountid__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h2 class=\\"sg-h2\\" id=\\"worklogs\\">Worklogs</h2>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_worklogs\\" href=\\"#panel_worklogs\\"><span class=\\"parent\\"></span>/worklogs</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_worklogs\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve worklogs</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#worklogs_get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#worklogs_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#worklogs_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"worklogs_get_request\\">
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>issue</strong>: <em>(array of string)</em><p>Retrieve only worklogs for the given issues. Issues may be specified by either issue ids or issue keys.</p></li>
+<li><strong>project</strong>: <em>(array of string)</em><p>Retrieve only worklogs for the given projects. Projects may be specified by either project ids or project keys.</p></li>
+<li><strong>from</strong>: <em>(date-only)</em><p>Retrieve results starting with this date</p></li>
+<li><strong>to</strong>: <em>(date-only)</em><p>Retrieve results up to and including this date</p></li>
+<li><strong>updatedFrom</strong>: <em>(date-only)</em><p>Retrieve results that have been updated from this date</p></li>
+<li><strong>offset?</strong>: <em>(integer - default: 0)</em><p>Skip over a number of elements by specifying an offset value for the query</p></li>
+<li><strong>limit?</strong>: <em>(integer - default: 50 - maximum: 1000)</em><p>Limit the number of elements on the response</p></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>offset</strong>: <em>required (integer - default: 0)</em></li><li><strong>limit</strong>: <em>required (integer - default: 50 - maximum: 1000)</em></li><li><strong>next</strong>: <em>(string)</em></li><li><strong>previous</strong>: <em>(string)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Worklog)</em><p><strong>Items</strong>: Worklog</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>tempoWorklogId</strong>: <em>required (integer)</em></li><li><strong>jiraWorklogId</strong>: <em>(integer)</em></li><li><strong>issue</strong>: <em>required (issue)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li></ul></li><li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>startTime</strong>: <em>required (time-only)</em></li><li><strong>description</strong>: <em>required (string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>author</strong>: <em>required (author)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>attributes</strong>: <em>(attributes)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>values</strong>: <em>required (array of Work Attribute Value)</em><p><strong>Items</strong>: Work Attribute Value</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em></li><li><strong>value</strong>: <em>required (any)</em></li></ul></div></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/worklogs?from=2017-02-01&amp;to=2017-02-28&amp;offset=0&amp;limit=50\\",
+  \\"metadata\\": {
+    \\"count\\": 18,
+    \\"offset\\": 0,
+    \\"limit\\": 50
+  },
+  \\"results\\": [
+    // skipped
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Creates a new worklog</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#worklogs_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#worklogs_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#worklogs_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"worklogs_post_request\\">
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>issueKey</strong>: <em>required (string)</em></li>
+<li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li>
+<li><strong>startDate</strong>: <em>required (date-only)</em></li>
+<li><strong>startTime</strong>: <em>required (time-only)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>authorAccountId</strong>: <em>required (string)</em></li>
+<li><strong>attributes</strong>: <em>(array of Work Attribute Value)</em><p><strong>Items</strong>: Work Attribute Value</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em></li><li><strong>value</strong>: <em>required (any)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"issueKey\\": \\"DUM-1\\",
+  \\"timeSpentSeconds\\": 3600,
+  \\"billableSeconds\\": 5200,
+  \\"startDate\\": \\"2017-02-06\\",
+  \\"startTime\\": \\"20:06:00\\",
+  \\"description\\": \\"Investigating a problem with our external database system\\", // optional depending on setting in Tempo Admin
+  \\"authorAccountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+  \\"remainingEstimateSeconds\\": 7200, // optional depending on setting in Tempo Admin
+  \\"attributes\\": [
+    {
+      \\"key\\": \\"_EXTERNALREF_\\",
+      \\"value\\": \\"EXT-32548\\"
+    },
+    {
+      \\"key\\": \\"_COLOR_\\",
+      \\"value\\": \\"green\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Worklog has been successfully created</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>tempoWorklogId</strong>: <em>required (integer)</em></li>
+<li><strong>jiraWorklogId</strong>: <em>(integer)</em></li>
+<li><strong>issue</strong>: <em>required (issue)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li>
+<li><strong>startDate</strong>: <em>required (date-only)</em></li>
+<li><strong>startTime</strong>: <em>required (time-only)</em></li>
+<li><strong>description</strong>: <em>required (string)</em></li>
+<li><strong>createdAt</strong>: <em>required (datetime)</em></li>
+<li><strong>updatedAt</strong>: <em>required (datetime)</em></li>
+<li><strong>author</strong>: <em>required (author)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>attributes</strong>: <em>(attributes)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>values</strong>: <em>required (array of Work Attribute Value)</em><p><strong>Items</strong>: Work Attribute Value</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em></li><li><strong>value</strong>: <em>required (any)</em></li></ul></div></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/worklogs/12600\\",
+  \\"tempoWorklogId\\": 126,
+  \\"jiraWorklogId\\": 10100,
+  \\"issue\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/issue/DUM-1\\",
+    \\"key\\": \\"DUM-1\\"
+  },
+  \\"timeSpentSeconds\\": 3600,
+  \\"billableSeconds\\": 5200,
+  \\"startDate\\": \\"2017-02-06\\",
+  \\"startTime\\": \\"20:06:00\\",
+  \\"description\\": \\"Investigating a problem with our external database system\\",
+  \\"createdAt\\": \\"2017-02-06T16:41:41Z\\",
+  \\"updatedAt\\": \\"2017-02-06T16:41:41Z\\",
+  \\"author\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+    \\"displayName\\": \\"John Brown\\"
+  },
+  \\"attributes\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/worklogs/126/work-attribute-values\\",
+    \\"values\\": [
+      {
+        \\"key\\": \\"_DELIVERED_\\",
+        \\"value\\": true
+      },
+      {
+        \\"key\\": \\"_EXTERNALREF_\\",
+        \\"value\\": \\"EXT-44556\\"
+      },
+      {
+        \\"key\\": \\"_COLOR_\\",
+        \\"value\\": \\"red\\"
+      }
+    ]
+  }
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Worklog cannot be created for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Issue not found\\"
+    },
+    {
+      \\"message\\": \\"Date can not be empty\\"
+    },
+    {
+      \\"message\\": \\"Invalid time duration entered\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_worklogs__worklogid_\\" href=\\"#panel_worklogs__worklogid_\\"><span class=\\"parent\\">/worklogs</span>/{worklogId}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_worklogs__worklogid_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve an existing worklog for the given id</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#worklogs__worklogid__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#worklogs__worklogid__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#worklogs__worklogid__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"worklogs__worklogid__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>worklogId</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs__worklogid__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Worklog data of the given id</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>tempoWorklogId</strong>: <em>required (integer)</em></li>
+<li><strong>jiraWorklogId</strong>: <em>(integer)</em></li>
+<li><strong>issue</strong>: <em>required (issue)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li>
+<li><strong>startDate</strong>: <em>required (date-only)</em></li>
+<li><strong>startTime</strong>: <em>required (time-only)</em></li>
+<li><strong>description</strong>: <em>required (string)</em></li>
+<li><strong>createdAt</strong>: <em>required (datetime)</em></li>
+<li><strong>updatedAt</strong>: <em>required (datetime)</em></li>
+<li><strong>author</strong>: <em>required (author)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>attributes</strong>: <em>(attributes)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>values</strong>: <em>required (array of Work Attribute Value)</em><p><strong>Items</strong>: Work Attribute Value</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em></li><li><strong>value</strong>: <em>required (any)</em></li></ul></div></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/worklogs/12600\\",
+  \\"tempoWorklogId\\": 126,
+  \\"jiraWorklogId\\": 10100,
+  \\"issue\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/issue/DUM-1\\",
+    \\"key\\": \\"DUM-1\\"
+  },
+  \\"timeSpentSeconds\\": 3600,
+  \\"billableSeconds\\": 5200,
+  \\"startDate\\": \\"2017-02-06\\",
+  \\"startTime\\": \\"20:06:00\\",
+  \\"description\\": \\"Investigating a problem with our external database system\\",
+  \\"createdAt\\": \\"2017-02-06T16:41:41Z\\",
+  \\"updatedAt\\": \\"2017-02-06T16:41:41Z\\",
+  \\"author\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+    \\"displayName\\": \\"John Brown\\"
+  },
+  \\"attributes\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/worklogs/126/work-attribute-values\\",
+    \\"values\\": [
+      {
+        \\"key\\": \\"_DELIVERED_\\",
+        \\"value\\": true
+      },
+      {
+        \\"key\\": \\"_EXTERNALREF_\\",
+        \\"value\\": \\"EXT-44556\\"
+      },
+      {
+        \\"key\\": \\"_COLOR_\\",
+        \\"value\\": \\"red\\"
+      }
+    ]
+  }
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Worklog cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Worklog cannot be found\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs__worklogid__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Update an existing worklog</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#worklogs__worklogid__put_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#worklogs__worklogid__put_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#worklogs__worklogid__put_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"worklogs__worklogid__put_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>worklogId</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>issueKey</strong>: <em>required (string)</em></li>
+<li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li>
+<li><strong>startDate</strong>: <em>required (date-only)</em></li>
+<li><strong>startTime</strong>: <em>required (time-only)</em></li>
+<li><strong>description</strong>: <em>(string)</em></li>
+<li><strong>authorAccountId</strong>: <em>required (string)</em></li>
+<li><strong>attributes</strong>: <em>(array of Work Attribute Value)</em><p><strong>Items</strong>: Work Attribute Value</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em></li><li><strong>value</strong>: <em>required (any)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"issueKey\\": \\"DUM-1\\",
+  \\"timeSpentSeconds\\": 3600,
+  \\"billableSeconds\\": 5200,
+  \\"startDate\\": \\"2017-02-06\\",
+  \\"startTime\\": \\"20:06:00\\",
+  \\"description\\": \\"Investigating a problem with our external database system\\", // optional depending on setting in Tempo Admin
+  \\"authorAccountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+  \\"remainingEstimateSeconds\\": 7200, // optional depending on setting in Tempo Admin
+  \\"attributes\\": [
+    {
+      \\"key\\": \\"_EXTERNALREF_\\",
+      \\"value\\": \\"EXT-32548\\"
+    },
+    {
+      \\"key\\": \\"_COLOR_\\",
+      \\"value\\": \\"green\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs__worklogid__put_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Worklog has been successfully updated</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>tempoWorklogId</strong>: <em>required (integer)</em></li>
+<li><strong>jiraWorklogId</strong>: <em>(integer)</em></li>
+<li><strong>issue</strong>: <em>required (issue)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li>
+<li><strong>startDate</strong>: <em>required (date-only)</em></li>
+<li><strong>startTime</strong>: <em>required (time-only)</em></li>
+<li><strong>description</strong>: <em>required (string)</em></li>
+<li><strong>createdAt</strong>: <em>required (datetime)</em></li>
+<li><strong>updatedAt</strong>: <em>required (datetime)</em></li>
+<li><strong>author</strong>: <em>required (author)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>attributes</strong>: <em>(attributes)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>values</strong>: <em>required (array of Work Attribute Value)</em><p><strong>Items</strong>: Work Attribute Value</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em></li><li><strong>value</strong>: <em>required (any)</em></li></ul></div></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/worklogs/12600\\",
+  \\"tempoWorklogId\\": 126,
+  \\"jiraWorklogId\\": 10100,
+  \\"issue\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/issue/DUM-1\\",
+    \\"key\\": \\"DUM-1\\"
+  },
+  \\"timeSpentSeconds\\": 3600,
+  \\"billableSeconds\\": 5200,
+  \\"startDate\\": \\"2017-02-06\\",
+  \\"startTime\\": \\"20:06:00\\",
+  \\"description\\": \\"Investigating a problem with our external database system\\",
+  \\"createdAt\\": \\"2017-02-06T16:41:41Z\\",
+  \\"updatedAt\\": \\"2017-02-06T16:41:41Z\\",
+  \\"author\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+    \\"displayName\\": \\"John Brown\\"
+  },
+  \\"attributes\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/worklogs/126/work-attribute-values\\",
+    \\"values\\": [
+      {
+        \\"key\\": \\"_DELIVERED_\\",
+        \\"value\\": true
+      },
+      {
+        \\"key\\": \\"_EXTERNALREF_\\",
+        \\"value\\": \\"EXT-44556\\"
+      },
+      {
+        \\"key\\": \\"_COLOR_\\",
+        \\"value\\": \\"red\\"
+      }
+    ]
+  }
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Worklog cannot be updated for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Issue not found\\"
+    },
+    {
+      \\"message\\": \\"Date can not be empty\\"
+    },
+    {
+      \\"message\\": \\"Invalid time duration entered\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Worklog cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Worklog cannot be found\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs__worklogid__put_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Delete an existing worklog</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#worklogs__worklogid__delete_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#worklogs__worklogid__delete_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#worklogs__worklogid__delete_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"worklogs__worklogid__delete_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>worklogId</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs__worklogid__delete_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
+<p>Worklog has been successfully deleted</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Worklog cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Worklog cannot be found\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs__worklogid__delete_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_worklogs__worklogid__work_attribute_values\\" href=\\"#panel_worklogs__worklogid__work_attribute_values\\"><span class=\\"parent\\">/worklogs/{worklogId}</span>/work-attribute-values</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_worklogs__worklogid__work_attribute_values\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve all work attribute values for the worklog</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#worklogs__worklogid__work_attribute_values_get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#worklogs__worklogid__work_attribute_values_get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#worklogs__worklogid__work_attribute_values_get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"worklogs__worklogid__work_attribute_values_get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>worklogId</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs__worklogid__work_attribute_values_get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>List of all work attribute values</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Work Attribute Value)</em><p><strong>Items</strong>: Work Attribute Value</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em></li><li><strong>value</strong>: <em>required (any)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/worklogs/126/work-attribute-values\\",
+  \\"metadata\\": {
+    \\"count\\": 3
+  },
+  \\"results\\": [
+    {
+      \\"key\\": \\"_DELIVERED_\\",
+      \\"value\\": true
+    },
+    {
+      \\"key\\": \\"_EXTERNALREF_\\",
+      \\"value\\": \\"EXT-44556\\"
+    },
+    {
+      \\"key\\": \\"_COLOR_\\",
+      \\"value\\": \\"red\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs__worklogid__work_attribute_values_get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_worklogs__worklogid__work_attribute_values__key_\\" href=\\"#panel_worklogs__worklogid__work_attribute_values__key_\\"><span class=\\"parent\\">/worklogs/{worklogId}/work-attribute-values</span>/{key}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_worklogs__worklogid__work_attribute_values__key_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve a specific work attribute value for the worklog</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#worklogs__worklogid__work_attribute_values__key__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#worklogs__worklogid__work_attribute_values__key__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#worklogs__worklogid__work_attribute_values__key__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"worklogs__worklogid__work_attribute_values__key__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>worklogId</strong>: <em>required (string)</em></li>
+<li><strong>key</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs__worklogid__work_attribute_values__key__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Work attribute value data of the given key</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+<li><strong>value</strong>: <em>required (any)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"key\\": \\"_COLOR_\\",
+  \\"value\\": \\"red\\"
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Work attribute value cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Work attribute value cannot be found\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs__worklogid__work_attribute_values__key__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_worklogs__worklogid__filter__jirafilterid_\\" href=\\"#panel_worklogs__worklogid__filter__jirafilterid_\\"><span class=\\"parent\\">/worklogs/{worklogId}</span>/filter/{jirafilterId}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_worklogs__worklogid__filter__jirafilterid_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve worklogs associated to the given JIRA filter id</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#worklogs__worklogid__filter__jirafilterid__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#worklogs__worklogid__filter__jirafilterid__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#worklogs__worklogid__filter__jirafilterid__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"worklogs__worklogid__filter__jirafilterid__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>worklogId</strong>: <em>required (string)</em></li>
+<li><strong>jirafilterId</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>from</strong>: <em>(date-only)</em><p>Retrieve results starting with this date</p></li>
+<li><strong>to</strong>: <em>(date-only)</em><p>Retrieve results up to and including this date</p></li>
+<li><strong>updatedFrom</strong>: <em>(date-only)</em><p>Retrieve results that have been updated from this date</p></li>
+<li><strong>offset?</strong>: <em>(integer - default: 0)</em><p>Skip over a number of elements by specifying an offset value for the query</p></li>
+<li><strong>limit?</strong>: <em>(integer - default: 50 - maximum: 1000)</em><p>Limit the number of elements on the response</p></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs__worklogid__filter__jirafilterid__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Worklogs of the given JIRA filter id</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>offset</strong>: <em>required (integer - default: 0)</em></li><li><strong>limit</strong>: <em>required (integer - default: 50 - maximum: 1000)</em></li><li><strong>next</strong>: <em>(string)</em></li><li><strong>previous</strong>: <em>(string)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Worklog)</em><p><strong>Items</strong>: Worklog</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>tempoWorklogId</strong>: <em>required (integer)</em></li><li><strong>jiraWorklogId</strong>: <em>(integer)</em></li><li><strong>issue</strong>: <em>required (issue)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li></ul></li><li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>startTime</strong>: <em>required (time-only)</em></li><li><strong>description</strong>: <em>required (string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>author</strong>: <em>required (author)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>attributes</strong>: <em>(attributes)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>values</strong>: <em>required (array of Work Attribute Value)</em><p><strong>Items</strong>: Work Attribute Value</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em></li><li><strong>value</strong>: <em>required (any)</em></li></ul></div></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/worklogs/jira/filter/10020?offset=0&amp;limit=50\\",
+  \\"metadata\\": {
+    \\"count\\": 64,
+    \\"offset\\": 0,
+    \\"limit\\": 50,
+    \\"next\\": \\"https://api.tempo.io/core/3/worklogs/jira/filter/10020?offset=50&amp;limit=50\\"
+  },
+  \\"results\\": [
+    // skipped
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs__worklogid__filter__jirafilterid__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_worklogs_account__accountkey_\\" href=\\"#panel_worklogs_account__accountkey_\\"><span class=\\"parent\\">/worklogs</span>/account/{accountKey}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_worklogs_account__accountkey_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve all worklogs associated to the given account key</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#worklogs_account__accountkey__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#worklogs_account__accountkey__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#worklogs_account__accountkey__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"worklogs_account__accountkey__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>accountKey</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>from</strong>: <em>(date-only)</em><p>Retrieve results starting with this date</p></li>
+<li><strong>to</strong>: <em>(date-only)</em><p>Retrieve results up to and including this date</p></li>
+<li><strong>updatedFrom</strong>: <em>(date-only)</em><p>Retrieve results that have been updated from this date</p></li>
+<li><strong>offset?</strong>: <em>(integer - default: 0)</em><p>Skip over a number of elements by specifying an offset value for the query</p></li>
+<li><strong>limit?</strong>: <em>(integer - default: 50 - maximum: 1000)</em><p>Limit the number of elements on the response</p></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs_account__accountkey__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Worklogs associated to the account</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>offset</strong>: <em>required (integer - default: 0)</em></li><li><strong>limit</strong>: <em>required (integer - default: 50 - maximum: 1000)</em></li><li><strong>next</strong>: <em>(string)</em></li><li><strong>previous</strong>: <em>(string)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Worklog)</em><p><strong>Items</strong>: Worklog</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>tempoWorklogId</strong>: <em>required (integer)</em></li><li><strong>jiraWorklogId</strong>: <em>(integer)</em></li><li><strong>issue</strong>: <em>required (issue)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li></ul></li><li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>startTime</strong>: <em>required (time-only)</em></li><li><strong>description</strong>: <em>required (string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>author</strong>: <em>required (author)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>attributes</strong>: <em>(attributes)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>values</strong>: <em>required (array of Work Attribute Value)</em><p><strong>Items</strong>: Work Attribute Value</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em></li><li><strong>value</strong>: <em>required (any)</em></li></ul></div></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/worklogs/account/ACC-1?offset=0&amp;limit=50\\",
+  \\"metadata\\": {
+    \\"count\\": 51,
+    \\"offset\\": 0,
+    \\"limit\\": 50,
+    \\"next\\": \\"https://api.tempo.io/core/3/worklogs/account/ACC-1?offset=50&amp;limit=50\\"
+  },
+  \\"results\\": [
+    // skipped
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs_account__accountkey__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_worklogs_issue__key_\\" href=\\"#panel_worklogs_issue__key_\\"><span class=\\"parent\\">/worklogs</span>/issue/{key}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_worklogs_issue__key_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve all worklogs associated to the given issue key</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#worklogs_issue__key__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#worklogs_issue__key__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#worklogs_issue__key__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"worklogs_issue__key__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>key</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>from</strong>: <em>(date-only)</em><p>Retrieve results starting with this date</p></li>
+<li><strong>to</strong>: <em>(date-only)</em><p>Retrieve results up to and including this date</p></li>
+<li><strong>updatedFrom</strong>: <em>(date-only)</em><p>Retrieve results that have been updated from this date</p></li>
+<li><strong>offset?</strong>: <em>(integer - default: 0)</em><p>Skip over a number of elements by specifying an offset value for the query</p></li>
+<li><strong>limit?</strong>: <em>(integer - default: 50 - maximum: 1000)</em><p>Limit the number of elements on the response</p></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs_issue__key__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Worklogs associated to the issue</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>offset</strong>: <em>required (integer - default: 0)</em></li><li><strong>limit</strong>: <em>required (integer - default: 50 - maximum: 1000)</em></li><li><strong>next</strong>: <em>(string)</em></li><li><strong>previous</strong>: <em>(string)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Worklog)</em><p><strong>Items</strong>: Worklog</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>tempoWorklogId</strong>: <em>required (integer)</em></li><li><strong>jiraWorklogId</strong>: <em>(integer)</em></li><li><strong>issue</strong>: <em>required (issue)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li></ul></li><li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>startTime</strong>: <em>required (time-only)</em></li><li><strong>description</strong>: <em>required (string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>author</strong>: <em>required (author)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>attributes</strong>: <em>(attributes)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>values</strong>: <em>required (array of Work Attribute Value)</em><p><strong>Items</strong>: Work Attribute Value</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em></li><li><strong>value</strong>: <em>required (any)</em></li></ul></div></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/worklogs/issue/PLAT-234\\",
+  \\"metadata\\": {
+    \\"count\\": 57,
+    \\"offset\\": 0,
+    \\"limit\\": 50,
+    \\"next\\": \\"https://api.tempo.io/core/3/worklogs/issue/PLAT-234?offset=50&amp;limit=50\\"
+  },
+  \\"results\\": [
+    // skipped
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Worklog cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Issue not found\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs_issue__key__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_worklogs_jira__jiraworklogid_\\" href=\\"#panel_worklogs_jira__jiraworklogid_\\"><span class=\\"parent\\">/worklogs/jira</span>/{jiraWorklogId}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_worklogs_jira__jiraworklogid_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve an existing worklog for the given JIRA worklog id</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#worklogs_jira__jiraworklogid__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#worklogs_jira__jiraworklogid__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#worklogs_jira__jiraworklogid__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"worklogs_jira__jiraworklogid__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>jiraWorklogId</strong>: <em>required (string)</em></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs_jira__jiraworklogid__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Worklog data of the given JIRA worklog id</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>tempoWorklogId</strong>: <em>required (integer)</em></li>
+<li><strong>jiraWorklogId</strong>: <em>(integer)</em></li>
+<li><strong>issue</strong>: <em>required (issue)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li>
+<li><strong>startDate</strong>: <em>required (date-only)</em></li>
+<li><strong>startTime</strong>: <em>required (time-only)</em></li>
+<li><strong>description</strong>: <em>required (string)</em></li>
+<li><strong>createdAt</strong>: <em>required (datetime)</em></li>
+<li><strong>updatedAt</strong>: <em>required (datetime)</em></li>
+<li><strong>author</strong>: <em>required (author)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li>
+<li><strong>attributes</strong>: <em>(attributes)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>values</strong>: <em>required (array of Work Attribute Value)</em><p><strong>Items</strong>: Work Attribute Value</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em></li><li><strong>value</strong>: <em>required (any)</em></li></ul></div></li></ul></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/worklogs/12600\\",
+  \\"tempoWorklogId\\": 126,
+  \\"jiraWorklogId\\": 10100,
+  \\"issue\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/issue/DUM-1\\",
+    \\"key\\": \\"DUM-1\\"
+  },
+  \\"timeSpentSeconds\\": 3600,
+  \\"billableSeconds\\": 5200,
+  \\"startDate\\": \\"2017-02-06\\",
+  \\"startTime\\": \\"20:06:00\\",
+  \\"description\\": \\"Investigating a problem with our external database system\\",
+  \\"createdAt\\": \\"2017-02-06T16:41:41Z\\",
+  \\"updatedAt\\": \\"2017-02-06T16:41:41Z\\",
+  \\"author\\": {
+    \\"self\\": \\"https://my-cloud-instance.atlassian.net/rest/api/2/user?accountId=1111aaaa2222bbbb3333cccc\\",
+    \\"accountId\\": \\"1111aaaa2222bbbb3333cccc\\",
+    \\"displayName\\": \\"John Brown\\"
+  },
+  \\"attributes\\": {
+    \\"self\\": \\"https://api.tempo.io/core/3/worklogs/126/work-attribute-values\\",
+    \\"values\\": [
+      {
+        \\"key\\": \\"_DELIVERED_\\",
+        \\"value\\": true
+      },
+      {
+        \\"key\\": \\"_EXTERNALREF_\\",
+        \\"value\\": \\"EXT-44556\\"
+      },
+      {
+        \\"key\\": \\"_COLOR_\\",
+        \\"value\\": \\"red\\"
+      }
+    ]
+  }
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Worklog cannot be found in the system</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Worklog cannot be found\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs_jira__jiraworklogid__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_worklogs_project__projectkey_\\" href=\\"#panel_worklogs_project__projectkey_\\"><span class=\\"parent\\">/worklogs</span>/project/{projectKey}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_worklogs_project__projectkey_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve all worklogs associated to the given project key</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#worklogs_project__projectkey__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#worklogs_project__projectkey__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#worklogs_project__projectkey__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"worklogs_project__projectkey__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>projectKey</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>from</strong>: <em>(date-only)</em><p>Retrieve results starting with this date</p></li>
+<li><strong>to</strong>: <em>(date-only)</em><p>Retrieve results up to and including this date</p></li>
+<li><strong>updatedFrom</strong>: <em>(date-only)</em><p>Retrieve results that have been updated from this date</p></li>
+<li><strong>offset?</strong>: <em>(integer - default: 0)</em><p>Skip over a number of elements by specifying an offset value for the query</p></li>
+<li><strong>limit?</strong>: <em>(integer - default: 50 - maximum: 1000)</em><p>Limit the number of elements on the response</p></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs_project__projectkey__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Worklogs associated to the project</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>offset</strong>: <em>required (integer - default: 0)</em></li><li><strong>limit</strong>: <em>required (integer - default: 50 - maximum: 1000)</em></li><li><strong>next</strong>: <em>(string)</em></li><li><strong>previous</strong>: <em>(string)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Worklog)</em><p><strong>Items</strong>: Worklog</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>tempoWorklogId</strong>: <em>required (integer)</em></li><li><strong>jiraWorklogId</strong>: <em>(integer)</em></li><li><strong>issue</strong>: <em>required (issue)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li></ul></li><li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>startTime</strong>: <em>required (time-only)</em></li><li><strong>description</strong>: <em>required (string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>author</strong>: <em>required (author)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>attributes</strong>: <em>(attributes)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>values</strong>: <em>required (array of Work Attribute Value)</em><p><strong>Items</strong>: Work Attribute Value</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em></li><li><strong>value</strong>: <em>required (any)</em></li></ul></div></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/worklogs/project/PRJ-1\\",
+  \\"metadata\\": {
+    \\"count\\": 51,
+    \\"offset\\": 0,
+    \\"limit\\": 50,
+    \\"next\\": \\"https://api.tempo.io/core/3/worklogs/project/PRJ-1?offset=50&amp;limit=50\\"
+  },
+  \\"results\\": [
+    // skipped
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs_project__projectkey__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_worklogs_team__teamid_\\" href=\\"#panel_worklogs_team__teamid_\\"><span class=\\"parent\\">/worklogs</span>/team/{teamId}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_worklogs_team__teamid_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#worklogs_team__teamid__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#worklogs_team__teamid__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#worklogs_team__teamid__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"worklogs_team__teamid__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>teamId</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>from</strong>: <em>(date-only)</em><p>Retrieve results starting with this date</p></li>
+<li><strong>to</strong>: <em>(date-only)</em><p>Retrieve results up to and including this date</p></li>
+<li><strong>updatedFrom</strong>: <em>(date-only)</em><p>Retrieve results that have been updated from this date</p></li>
+<li><strong>offset?</strong>: <em>(integer - default: 0)</em><p>Skip over a number of elements by specifying an offset value for the query</p></li>
+<li><strong>limit?</strong>: <em>(integer - default: 50 - maximum: 1000)</em><p>Limit the number of elements on the response</p></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs_team__teamid__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Worklogs associated to the team</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>offset</strong>: <em>required (integer - default: 0)</em></li><li><strong>limit</strong>: <em>required (integer - default: 50 - maximum: 1000)</em></li><li><strong>next</strong>: <em>(string)</em></li><li><strong>previous</strong>: <em>(string)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Worklog)</em><p><strong>Items</strong>: Worklog</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>tempoWorklogId</strong>: <em>required (integer)</em></li><li><strong>jiraWorklogId</strong>: <em>(integer)</em></li><li><strong>issue</strong>: <em>required (issue)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li></ul></li><li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>startTime</strong>: <em>required (time-only)</em></li><li><strong>description</strong>: <em>required (string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>author</strong>: <em>required (author)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>attributes</strong>: <em>(attributes)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>values</strong>: <em>required (array of Work Attribute Value)</em><p><strong>Items</strong>: Work Attribute Value</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em></li><li><strong>value</strong>: <em>required (any)</em></li></ul></div></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/worklogs/team/42\\",
+  \\"metadata\\": {
+    \\"count\\": 0,
+    \\"offset\\": 0,
+    \\"limit\\": 50
+  },
+  \\"results\\": [
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs_team__teamid__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_worklogs_user__accountid_\\" href=\\"#panel_worklogs_user__accountid_\\"><span class=\\"parent\\">/worklogs</span>/user/{accountId}</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_worklogs_user__accountid_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Retrieve all worklogs associated to the given user</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#worklogs_user__accountid__get_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#worklogs_user__accountid__get_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#worklogs_user__accountid__get_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"worklogs_user__accountid__get_request\\">
+<h3>URI Parameters</h3>
+<ul>
+<li><strong>accountId</strong>: <em>required (string)</em></li>
+</ul>
+<h3>Query Parameters</h3>
+<ul>
+<li><strong>from</strong>: <em>(date-only)</em><p>Retrieve results starting with this date</p></li>
+<li><strong>to</strong>: <em>(date-only)</em><p>Retrieve results up to and including this date</p></li>
+<li><strong>updatedFrom</strong>: <em>(date-only)</em><p>Retrieve results that have been updated from this date</p></li>
+<li><strong>offset?</strong>: <em>(integer - default: 0)</em><p>Skip over a number of elements by specifying an offset value for the query</p></li>
+<li><strong>limit?</strong>: <em>(integer - default: 50 - maximum: 1000)</em><p>Limit the number of elements on the response</p></li>
+</ul>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs_user__accountid__get_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2>
+<p>Worklogs associated to the user</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>self</strong>: <em>required (string)</em></li>
+<li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li><li><strong>offset</strong>: <em>required (integer - default: 0)</em></li><li><strong>limit</strong>: <em>required (integer - default: 50 - maximum: 1000)</em></li><li><strong>next</strong>: <em>(string)</em></li><li><strong>previous</strong>: <em>(string)</em></li></ul></li>
+<li><strong>results</strong>: <em>required (array of Worklog)</em><p><strong>Items</strong>: Worklog</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>tempoWorklogId</strong>: <em>required (integer)</em></li><li><strong>jiraWorklogId</strong>: <em>(integer)</em></li><li><strong>issue</strong>: <em>required (issue)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li></ul></li><li><strong>timeSpentSeconds</strong>: <em>required (number)</em></li><li><strong>startDate</strong>: <em>required (date-only)</em></li><li><strong>startTime</strong>: <em>required (time-only)</em></li><li><strong>description</strong>: <em>required (string)</em></li><li><strong>createdAt</strong>: <em>required (datetime)</em></li><li><strong>updatedAt</strong>: <em>required (datetime)</em></li><li><strong>author</strong>: <em>required (author)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>accountId</strong>: <em>required (string)</em></li><li><strong>displayName</strong>: <em>required (string)</em></li></ul></li><li><strong>attributes</strong>: <em>(attributes)</em><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>values</strong>: <em>required (array of Work Attribute Value)</em><p><strong>Items</strong>: Work Attribute Value</p><div class=\\"items\\"><ul><li><strong>key</strong>: <em>required (string)</em></li><li><strong>value</strong>: <em>required (any)</em></li></ul></div></li></ul></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"self\\": \\"https://api.tempo.io/core/3/worklogs/user/john?offset=100&amp;limit=50\\",
+  \\"metadata\\": {
+    \\"count\\": 250,
+    \\"offset\\": 100,
+    \\"limit\\": 50,
+    \\"next\\": \\"https://api.tempo.io/core/3/worklogs/user/john?offset=150&amp;limit=50\\",
+    \\"previous\\": \\"https://api.tempo.io/core/3/worklogs/user/john?offset=50&amp;limit=50\\"
+  },
+  \\"results\\": [
+    // skipped
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs_user__accountid__get_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=\\"panel panel-default\\">
+<div class=\\"panel-heading\\">
+<a data-toggle=\\"collapse\\" data-target=\\"#panel_worklogs_work_attribute_values\\" href=\\"#panel_worklogs_work_attribute_values\\"><span class=\\"parent\\">/worklogs</span>/work-attribute-values</a>
+<span class=\\"methods\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+</span>
+</div>
+<div class=\\"panel-group\\">
+<div id=\\"panel_worklogs_work_attribute_values\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\">
+<div class=\\"panel-body\\">
+<div class=\\"list-group\\">
+<div class=\\"list-group-item\\">
+<div class=\\"resource_method_title\\">
+<span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
+<div class=\\"method_description\\">
+<p>Bulk create work attribute values for worklogs</p>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+<div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div>
+<ul class=\\"nav nav-tabs\\">
+<li class=\\"active\\">
+<a href=\\"#worklogs_work_attribute_values_post_request\\" data-toggle=\\"tab\\">Request</a>
+</li>
+<li>
+<a href=\\"#worklogs_work_attribute_values_post_response\\" data-toggle=\\"tab\\">Response</a>
+</li>
+<li>
+<a href=\\"#worklogs_work_attribute_values_post_securedby\\" data-toggle=\\"tab\\">Security</a>
+</li>
+</ul>
+<div class=\\"tab-content\\">
+<div class=\\"tab-pane active\\" id=\\"worklogs_work_attribute_values_post_request\\">
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>tempoWorklogId</strong>: <em>required (integer)</em></li>
+<li><strong>attributeValues</strong>: <em>required (string)</em></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>[
+  {
+    \\"tempoWorklogId\\": 10100,
+    \\"attributeValues\\": [
+      {
+        \\"key\\": \\"_COLOR_\\",
+        \\"value\\": \\"red\\"
+      }
+    ]
+  },
+  {
+    \\"tempoWorklogId\\": 10101,
+    \\"attributeValues\\": [
+      {
+        \\"key\\": \\"_DELIVERED_\\",
+        \\"value\\": true
+      },
+      {
+        \\"key\\": \\"_EXTERNALREF_\\",
+        \\"value\\": \\"EXT-44556\\"
+      }
+    ]
+  }
+]
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs_work_attribute_values_post_response\\">
+<h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
+<p>Work attribute values have been created</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
+<p>Work attribute values cannot be created for some reasons</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"Invalid work attribute value\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2>
+<p>Client must be authenticated to access this resource.</p>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2>
+<p>Authenticated user is missing permission to fulfill the request</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h2>HTTP status code <a href=\\"http://httpstatus.es/404\\" target=\\"_blank\\">404</a></h2>
+<p>Worklog or Work attribute key not found</p>
+<h3>Body</h3>
+<p><strong>Media type</strong>: application/json</p>
+<p><strong>Type</strong>: object</p>
+<strong>Properties</strong>
+<ul>
+<li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li>
+</ul>
+<p><strong>Example</strong>:</p>
+<div class=\\"examples\\">
+<pre>
+<code>{
+  \\"errors\\": [
+    {
+      \\"message\\": \\"A work attribute with key &#39;_COLOR_&#39; does not exist\\"
+    }
+  ]
+}
+</code>
+</pre>
+</div>
+</div>
+<div class=\\"tab-pane\\" id=\\"worklogs_work_attribute_values_post_securedby\\">
+<h1>Secured by OAuth 2.0</h1>
+<h3>Headers</h3>
+<ul>
+<li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li>
+</ul>
+</div>
+</div>
+<div class=\\"clearfix\\"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</p>
+</div>
+</section>
+</nav>
+</article>
+</body>
+</link>
+</link>
+</link>
+</meta>
+</meta>
+</meta>
+</head>
+</html>"
+`;
+
 exports[`Tempo REST API Documentation has not changed 1`] = `
 "<!DOCTYPE HTML><html><head><title>REST API documentation</title><meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\"><meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=utf-8\\"><meta name=\\"generator\\" content=\\"https://github.com/raml2html/raml2html 7.5.0\\"><link rel=\\"stylesheet\\" href=\\"https://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css\\"><link rel=\\"stylesheet\\" href=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/styles/default.min.css\\"><script type=\\"text/javascript\\" src=\\"https://code.jquery.com/jquery-1.11.0.min.js\\"></script><script type=\\"text/javascript\\" src=\\"https://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js\\"></script><script type=\\"text/javascript\\" src=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/highlight.min.js\\"></script><script type=\\"text/javascript\\">
       $(document).ready(function() {

--- a/tests/tempoDocumentation.test.ts
+++ b/tests/tempoDocumentation.test.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import format = require('xml-formatter');
 
 let responseData = '<html lang="en-us"></html>';
 let htmlDoc: Document = new Document();
@@ -21,6 +22,14 @@ describe('Tempo REST API Documentation', () => {
 
   it('has not changed', () => {
     expect(responseData).toMatchSnapshot();
+  });
+
+  it('formatted XML has not changed', () => {
+    expect(format(responseData, {
+      collapseContent: true,
+      indentation: '',
+      lineSeparator: '\n',
+    })).toMatchSnapshot();
   });
 
   it('has the same panel-heading', () => {


### PR DESCRIPTION
One of the tests checks whether the content of https://tempo-io.github.io/tempo-api-docs/ has changed. Specifically: "has not changed".

However, this test was unhelpful since the diffs in the HTML snapshot would span multiple sections, and conflate changes with non-changes a lot of the time because newline characters are used infrequently in the HTML itself.

By formatting the HTML and putting certain tags on different lines, diffing the response will hopefully be less problematic.

We'll still keep the old test just in case we need to spot if there are any whitespace changes that we might need to be concerned about.