### PR TITLE
Type definition updates + Test fixes + NPM Update (devDependencies)

### DIFF
--- a/jestconfig.json
+++ b/jestconfig.json
@@ -1,4 +1,5 @@
 {
+  "testEnvironment": "node",
   "transform": {
     "^.+\\.(t|j)sx?$": "ts-jest"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1051,9 +1051,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
-      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==",
+      "version": "14.14.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.28.tgz",
+      "integrity": "sha512-lg55ArB+ZiHHbBBttLpzD07akz0QPrZgUODNakeC09i62dnrywr9mFErHuaPlB6I7z+sEbK+IYmplahvplCj2g==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1102,33 +1102,104 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.14.2.tgz",
-      "integrity": "sha512-uMGfG7GFYK/nYutK/iqYJv6K/Xuog/vrRRZX9aEP4Zv1jsYXuvFUMDFLhUnc8WFv3D2R5QhNQL3VYKmvLS5zsQ==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.15.0.tgz",
+      "integrity": "sha512-DJgdGZW+8CFUTz5C/dnn4ONcUm2h2T0itWD85Ob5/V27Ndie8hUoX5HKyGssvR8sUMkAIlUc/AMK67Lqa3kBIQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.14.2",
-        "@typescript-eslint/scope-manager": "4.14.2",
+        "@typescript-eslint/experimental-utils": "4.15.0",
+        "@typescript-eslint/scope-manager": "4.15.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.15",
         "regexpp": "^3.0.0",
         "semver": "^7.3.2",
         "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "4.15.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.15.0.tgz",
+          "integrity": "sha512-CSNBZnCC2jEA/a+pR9Ljh8Y+5TY5qgbPz7ICEk9WCpSEgT6Pi7H2RIjxfrrbUXvotd6ta+i27sssKEH8Azm75g==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.15.0",
+            "@typescript-eslint/visitor-keys": "4.15.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "4.15.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.15.0.tgz",
+          "integrity": "sha512-su4RHkJhS+iFwyqyXHcS8EGPlUVoC+XREfy5daivjLur9JP8GhvTmDipuRpcujtGC4M+GYhUOJCPDE3rC5NJrg==",
+          "dev": true
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "4.15.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.0.tgz",
+          "integrity": "sha512-RnDtJwOwFucWFAMjG3ghCG/ikImFJFEg20DI7mn4pHEx3vC48lIAoyjhffvfHmErRDboUPC7p9Z2il4CLb7qxA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.15.0",
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        }
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.14.2.tgz",
-      "integrity": "sha512-mV9pmET4C2y2WlyHmD+Iun8SAEqkLahHGBkGqDVslHkmoj3VnxnGP4ANlwuxxfq1BsKdl/MPieDbohCEQgKrwA==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.15.0.tgz",
+      "integrity": "sha512-V4vaDWvxA2zgesg4KPgEGiomWEBpJXvY4ZX34Y3qxK8LUm5I87L+qGIOTd9tHZOARXNRt9pLbblSKiYBlGMawg==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.14.2",
-        "@typescript-eslint/types": "4.14.2",
-        "@typescript-eslint/typescript-estree": "4.14.2",
+        "@typescript-eslint/scope-manager": "4.15.0",
+        "@typescript-eslint/types": "4.15.0",
+        "@typescript-eslint/typescript-estree": "4.15.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "4.15.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.15.0.tgz",
+          "integrity": "sha512-CSNBZnCC2jEA/a+pR9Ljh8Y+5TY5qgbPz7ICEk9WCpSEgT6Pi7H2RIjxfrrbUXvotd6ta+i27sssKEH8Azm75g==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.15.0",
+            "@typescript-eslint/visitor-keys": "4.15.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "4.15.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.15.0.tgz",
+          "integrity": "sha512-su4RHkJhS+iFwyqyXHcS8EGPlUVoC+XREfy5daivjLur9JP8GhvTmDipuRpcujtGC4M+GYhUOJCPDE3rC5NJrg==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "4.15.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.15.0.tgz",
+          "integrity": "sha512-jG6xTmcNbi6xzZq0SdWh7wQ9cMb2pqXaUp6bUZOMsIlu5aOlxGxgE/t6L/gPybybQGvdguajXGkZKSndZJpksA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.15.0",
+            "@typescript-eslint/visitor-keys": "4.15.0",
+            "debug": "^4.1.1",
+            "globby": "^11.0.1",
+            "is-glob": "^4.0.1",
+            "semver": "^7.3.2",
+            "tsutils": "^3.17.1"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "4.15.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.0.tgz",
+          "integrity": "sha512-RnDtJwOwFucWFAMjG3ghCG/ikImFJFEg20DI7mn4pHEx3vC48lIAoyjhffvfHmErRDboUPC7p9Z2il4CLb7qxA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.15.0",
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        }
       }
     },
     "@typescript-eslint/parser": {
@@ -3124,9 +3195,9 @@
       "optional": true
     },
     "handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5",
@@ -5060,9 +5131,9 @@
       }
     },
     "marked": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.9.tgz",
-      "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.0.tgz",
+      "integrity": "sha512-NqRSh2+LlN2NInpqTQnS614Y/3NkVMFFU6sJlRFEpxJ/LHuK/qJECH7/fXZjk4VZstPW/Pevjil/VtSONsLc7Q==",
       "dev": true
     },
     "merge-stream": {
@@ -6856,9 +6927,9 @@
       }
     },
     "typedoc": {
-      "version": "0.20.23",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.23.tgz",
-      "integrity": "sha512-RBXuM0MJ2V/7eGg4YrDEmV1bn/ypa3Wx6AO1B0mUBHEQJaOIKEEnNI0Su75J6q7dkB5ksZvGNgsGjvfWL8Myjg==",
+      "version": "0.20.25",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.25.tgz",
+      "integrity": "sha512-ZQZnjJPrt0rjp216gp6FQC1QC4ojcoKikhfOJ/51CqaJunVDilRLlIO5tCGWj1tzlYYT9eOGhJv7MF3t7rxSmw==",
       "dev": true,
       "requires": {
         "colors": "^1.4.0",
@@ -6866,7 +6937,7 @@
         "handlebars": "^4.7.6",
         "lodash": "^4.17.20",
         "lunr": "^2.3.9",
-        "marked": "^1.2.9",
+        "marked": "^2.0.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
         "shelljs": "^0.8.4",
@@ -6895,9 +6966,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.12.7",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.7.tgz",
-      "integrity": "sha512-SIZhkoh+U/wjW+BHGhVwE9nt8tWJspncloBcFapkpGRwNPqcH8pzX36BXe3TPBjzHWPMUZotpCigak/udWNr1Q==",
+      "version": "3.12.8",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.8.tgz",
+      "integrity": "sha512-fvBeuXOsvqjecUtF/l1dwsrrf5y2BCUk9AOJGzGcm6tE7vegku5u/YvqjyDaAGr422PLoLnrxg3EnRvTqsdC1w==",
       "dev": true,
       "optional": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1027,6 +1027,17 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "@types/jsdom": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-16.2.6.tgz",
+      "integrity": "sha512-yQA+HxknGtW9AkRTNyiSH3OKW5V+WzO8OPTdne99XwJkYC+KYxfNIcoJjeiSqP3V00PUUpFP6Myoo9wdIu78DQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/parse5": "*",
+        "@types/tough-cookie": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -1051,6 +1062,12 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
+    "@types/parse5": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.0.tgz",
+      "integrity": "sha512-oPwPSj4a1wu9rsXTEGIJz91ISU725t0BmSnUhb57sI+M8XEmvUop84lzuiYdq0Y5M6xLY8DBPg0C2xEQKLyvBA==",
+      "dev": true
+    },
     "@types/prettier": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.5.tgz",
@@ -1061,6 +1078,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+      "dev": true
+    },
+    "@types/tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
       "dev": true
     },
     "@types/yargs": {
@@ -2245,12 +2268,12 @@
       }
     },
     "eslint": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.19.0.tgz",
-      "integrity": "sha512-CGlMgJY56JZ9ZSYhJuhow61lMPPjUzWmChFya71Z/jilVos7mR/jPgaEfVGgMBY5DshbKdG8Ezb8FDCHcoMEMg==",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.20.0.tgz",
+      "integrity": "sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
+        "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.3.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -2262,7 +2285,7 @@
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^2.0.0",
         "espree": "^7.3.1",
-        "esquery": "^1.2.0",
+        "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "file-entry-cache": "^6.0.0",
         "functional-red-black-tree": "^1.0.1",
@@ -2289,6 +2312,15 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
         "lodash": {
           "version": "4.17.20",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
@@ -2510,9 +2542,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
-      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
@@ -5056,18 +5088,18 @@
       }
     },
     "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
       "dev": true,
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.45.0"
       }
     },
     "mimic-fn": {
@@ -6571,9 +6603,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.3.tgz",
-          "integrity": "sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.1.0.tgz",
+          "integrity": "sha512-svS9uILze/cXbH0z2myCK2Brqprx/+JJYK5pHicT/GQiBfzzhUVAIT6MwqJg8y4xV/zoGsUeuPuwtoiKSGE15g==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -6716,9 +6748,9 @@
       }
     },
     "ts-jest": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.0.tgz",
-      "integrity": "sha512-Ya4IQgvIFNa2Mgq52KaO8yBw2W8tWp61Ecl66VjF0f5JaV8u50nGoptHVILOPGoI7SDnShmEqnYQEmyHdQ+56g==",
+      "version": "26.5.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.1.tgz",
+      "integrity": "sha512-G7Rmo3OJMvlqE79amJX8VJKDiRcd7/r61wh9fnvvG8cAjhA9edklGw/dCxRSQmfZ/z8NDums5srSVgwZos1qfg==",
       "dev": true,
       "requires": {
         "@types/jest": "26.x",
@@ -6735,18 +6767,18 @@
       },
       "dependencies": {
         "json5": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
           }
         },
         "yargs-parser": {
-          "version": "20.2.4",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+          "version": "20.2.5",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.5.tgz",
+          "integrity": "sha512-jYRGS3zWy20NtDtK2kBgo/TlAoy5YUuhD9/LZ7z7W4j1Fdw2cqD0xEEclf8fxc8xjD6X5Qr+qQQwCEsP8iRiYg==",
           "dev": true
         }
       }
@@ -6857,9 +6889,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
       "dev": true
     },
     "uglify-js": {
@@ -7153,9 +7185,9 @@
       }
     },
     "ws": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
+      "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
       "dev": true
     },
     "xml-formatter": {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   "devDependencies": {
     "@types/jest": "^26.0.20",
     "@types/jsdom": "^16.2.6",
-    "@types/node": "^14.14.25",
-    "@typescript-eslint/eslint-plugin": "^4.14.2",
+    "@types/node": "^14.14.28",
+    "@typescript-eslint/eslint-plugin": "^4.15.0",
     "codecov": "^3.8.1",
     "eslint": "^7.20.0",
     "eslint-config-airbnb-typescript": "^12.3.1",
@@ -45,7 +45,7 @@
     "jest": "^26.6.3",
     "jsdom": "^16.4.0",
     "ts-jest": "^26.5.1",
-    "typedoc": "^0.20.23",
+    "typedoc": "^0.20.25",
     "typescript": "^4.1.5",
     "xml-formatter": "^2.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -35,16 +35,18 @@
   "homepage": "https://github.com/leifgehrmann/node-tempo-client#readme",
   "devDependencies": {
     "@types/jest": "^26.0.20",
+    "@types/jsdom": "^16.2.6",
     "@types/node": "^14.14.25",
     "@typescript-eslint/eslint-plugin": "^4.14.2",
     "codecov": "^3.8.1",
-    "eslint": "^7.19.0",
+    "eslint": "^7.20.0",
     "eslint-config-airbnb-typescript": "^12.3.1",
     "eslint-plugin-import": "^2.22.1",
     "jest": "^26.6.3",
-    "ts-jest": "^26.5.0",
+    "jsdom": "^16.4.0",
+    "ts-jest": "^26.5.1",
     "typedoc": "^0.20.23",
-    "typescript": "^4.1.3",
+    "typescript": "^4.1.5",
     "xml-formatter": "^2.4.0"
   },
   "dependencies": {

--- a/src/collections/worklogs.ts
+++ b/src/collections/worklogs.ts
@@ -11,6 +11,7 @@ export default class Worklogs extends Collection {
   public async get(
     options?: Partial<
     queryOptions.Issues &
+    queryOptions.Projects &
     queryOptions.DateRange &
     queryOptions.UpdatedFrom &
     queryOptions.Pagination

--- a/src/queryOptionTypes.ts
+++ b/src/queryOptionTypes.ts
@@ -22,6 +22,10 @@ export interface Issues {
   issue: string[];
 }
 
+export interface Projects {
+  project: string[];
+}
+
 export interface Status extends StringMap {
   status: 'OPEN' | 'CLOSED' | 'ARCHIVED';
 }

--- a/src/requestTypes.ts
+++ b/src/requestTypes.ts
@@ -126,6 +126,7 @@ export interface WorkAttribute {
   type: 'ACCOUNT' | 'CHECKBOX' | 'INPUT_FIELD' | 'INPUT_NUMERIC' | 'STATIC_LIST';
   required: boolean; // Tempo.io documentation claims this defaults to false, but is still required
   values?: string[]; // Only required for 'STATIC_LIST' attribute types
+  names?: { [key: string]: string }; // Only relevant for 'STATIC_LIST' attribute types
 }
 
 export interface WorklogAttributeValue {

--- a/tests/__snapshots__/tempoDocumentation.test.ts.snap
+++ b/tests/__snapshots__/tempoDocumentation.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
 <title>REST API documentation</title>
 <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\">
 <meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=utf-8\\">
-<meta name=\\"generator\\" content=\\"https://github.com/raml2html/raml2html 7.5.0\\">
+<meta name=\\"generator\\" content=\\"https://github.com/raml2html/raml2html 7.7.0\\">
 <link rel=\\"stylesheet\\" href=\\"https://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css\\">
 <link rel=\\"stylesheet\\" href=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/styles/default.min.css\\">
 <script type=\\"text/javascript\\" src=\\"https://code.jquery.com/jquery-1.11.0.min.js\\"></script>
@@ -240,6 +240,18 @@ exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
 <a href=\\"https://tempo-io.github.io/tempo-audit-docs/\\">Endpoints</a>
 </li>
 </ul>
+<div class=\\"sg-nav__spacer\\">Cost-Tracker API (Beta)</div>
+<ul class=\\"sg-nav__links\\">
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"https://apidocs.tempo.io/cost-tracker\\">Endpoints</a>
+</li>
+</ul>
+<div class=\\"sg-nav__spacer\\">Jira Links API (Beta)</div>
+<ul class=\\"sg-nav__links\\">
+<li class=\\"sg-nav__links__element\\">
+<a href=\\"https://apidocs.tempo.io/jira\\">Endpoints</a>
+</li>
+</ul>
 </img>
 </div>
 <section class=\\"sg-section sg-section--main\\">
@@ -247,28 +259,8 @@ exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
 <h1 class=\\"sg-h1\\">REST API documentation <small>version 3</small></h1>
 <p class=\\"sg-p\\">https://api.tempo.io/core/{version}</p>
 <p class=\\"sg-p\\"></p>
-<h3>About the Tempo REST API</h3>
-<p class=\\"sg-p\\">
-<strong>Version 3 of the Tempo REST API is available as of February 1st, 2019.</strong>
-</p>
-<p class=\\"sg-p\\">
-<strong>As of March 29th, 2019, version 2 has been decomissioned. Everyone using the API is encouraged to switch to version 3.</strong>
-</p>
-<p class=\\"sg-p\\">
-<strong>For more information, see <a href=\\"https://tempo-io.atlassian.net/wiki/spaces/CLOUDNEWS/pages/358810021/2018-12-07+Action+Required+for+API+Users+Jira+Cloud+Privacy+Updates\\">this announcement</a>.</strong>
-</p>
-<p class=\\"sg-p\\">The REST API is designed around a flexible and scalable architecture that will extend in lockstep with Tempo’s development.</p>
 <p class=\\"sg-p\\">We encourage you to join our developer community on Slack at <a href=\\"https://www.tempo.io/developers\\">www.tempo.io/developers</a>, where you can get support from our internal experts and share best practices with other developers building with Tempo.</p>
 <p class=\\"sg-p\\">If you have feedback or requests, you can also reach us through our <a href=\\"https://tempo-io.atlassian.net/servicedesk/customer/portal/6\\">Customer Support Portal</a>. You can find general product information in the <a href=\\"https://www.tempo.io/documentation\\">Tempo Help Center</a>.</p>
-<h3>Changes from version 2</h3>
-<h4>Privacy improvements</h4>
-<p class=\\"sg-p\\">All APIs that previously used a username to identify users now use accountId instead. Field names in JSON documents have changed accordingly, for example <code>leadUsername</code> has been replaced with <code>leadAccountId</code>.</p>
-<h4>Account contact</h4>
-<p class=\\"sg-p\\">When creating an account, separate fields are used to identify the contact depending on whether the contact is a registered Jira user.</p>
-<p class=\\"sg-p\\">The <code>contactAccountId</code> field is used to identify the contact if the contact is a registered Jira user. The <code>externalContactName</code> field is used if the contact is not a registered Jira user.</p>
-<p class=\\"sg-p\\">In account responses, a new <code>type</code> field marks the contact as a Jira user (USER) or not (EXTERNAL).</p>
-<h4>Team permission update</h4>
-<p class=\\"sg-p\\">The API for updating team permissions has been removed.</p>
 <h3>Using the REST API as an individual user</h3>
 <p class=\\"sg-p\\">You can use the REST API to interact with the data your permissions give you access to. To do so, you will need to generate a Tempo OAuth 2.0 token.</p>
 <p class=\\"sg-p\\">Go to <b>Tempo>Settings</b>, scroll down to <b>Data Access</b> and select <b>API integration</b>.</p>
@@ -339,6 +331,10 @@ exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
 <p class=\\"sg-p\\">The API uses strings to represent dates. Dates are formatted as <a href=\\"https://en.wikipedia.org/wiki/ISO_8601#Calendar_dates\\">ISO 8601 calendar dates</a> (YYYY-MM-DD). For example, March 29th, 2019 is formatted as 2019-03-29.</p>
 <h4>Delete requests</h4>
 <p class=\\"sg-p\\">On success, delete requests return a response with status code <a href=\\"https://httpstatuses.com/204\\">204 (No content)</a>. No payload body is included in the response.</p>
+<h4>Arrays</h4>
+<p class=\\"sg-p\\">A few endpoints accept query parameters of type array. That is achieved by repeating the parameter multiple times, e.g. to get worklogs from three projects:<pre>
+.../worklogs?from=2020-01-01&to=2020-12-31&project=10100&project=10200&project=10300
+</pre></p>
 <p></p>
 <ul>
 <li><strong>version</strong>: <em>required (3)</em></li>
@@ -12271,7 +12267,7 @@ exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
 <ul>
 <li><strong>self</strong>: <em>required (string)</em></li>
 <li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li>
-<li><strong>results</strong>: <em>required (array of Work Attribute)</em><p><strong>Items</strong>: Work Attribute</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li><li><strong>required</strong>: <em>required (boolean - default: false)</em></li><li><strong>values</strong>: <em>(array of )</em></li></ul></div></li>
+<li><strong>results</strong>: <em>required (array of Work Attribute)</em><p><strong>Items</strong>: Work Attribute</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li><li><strong>required</strong>: <em>required (boolean - default: false)</em></li><li><strong>values</strong>: <em>(array of )</em><p>Only relevant when type is STATIC_LIST. These values are immutable. Their UI representation can be looked up in the <code>names</code> object below.</p></li><li><strong>names</strong>: <em>(names)</em><p>Only relevant when type is STATIC_LIST. Each STATIC_LIST entry has an immutable <code>value</code> which is stored with the worklog, and a <code>name</code> that is shown in the UI. The <code>name</code> can be changed.</p><ul></ul></li></ul></div></li>
 </ul>
 <p><strong>Example</strong>:</p>
 <div class=\\"examples\\">
@@ -12289,12 +12285,19 @@ exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
       \\"type\\": \\"STATIC_LIST\\",
       \\"required\\": false,
       \\"values\\": [
-        \\"red\\",
-        \\"green\\",
-        \\"blue\\",
-        \\"yellow\\",
-        \\"pink\\"
-      ]
+        \\"Red\\",
+        \\"Green\\",
+        \\"LightBlue\\",
+        \\"Yellow\\",
+        \\"Pink\\"
+      ],
+      \\"names\\": {
+        \\"Red\\": \\"Red\\",
+        \\"Green\\": \\"Green\\",
+        \\"LightBlue\\": \\"Light Blue\\",
+        \\"Yellow\\": \\"Yellow\\",
+        \\"Pink\\": \\"Rosé\\"
+      }
     },
     {
       \\"self\\": \\"https://api.tempo.io/core/3/work-attributes/_EXTERNALREF_\\",
@@ -12384,11 +12387,11 @@ exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
   \\"type\\": \\"STATIC_LIST\\",
   \\"required\\": false,
   \\"values\\": [
-    \\"red\\",
-    \\"green\\",
-    \\"blue\\",
-    \\"yellow\\",
-    \\"pink\\"
+    \\"Red\\",
+    \\"Green\\",
+    \\"Light Blue\\",
+    \\"Yellow\\",
+    \\"Pink\\"
   ]
 }
 </code>
@@ -12408,7 +12411,8 @@ exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
 <li><strong>name</strong>: <em>required (string)</em></li>
 <li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li>
 <li><strong>required</strong>: <em>required (boolean - default: false)</em></li>
-<li><strong>values</strong>: <em>(array of )</em></li>
+<li><strong>values</strong>: <em>(array of )</em><p>Only relevant when type is STATIC_LIST. These values are immutable. Their UI representation can be looked up in the <code>names</code> object below.</p></li>
+<li><strong>names</strong>: <em>(names)</em><p>Only relevant when type is STATIC_LIST. Each STATIC_LIST entry has an immutable <code>value</code> which is stored with the worklog, and a <code>name</code> that is shown in the UI. The <code>name</code> can be changed.</p><ul></ul></li>
 </ul>
 <p><strong>Example</strong>:</p>
 <div class=\\"examples\\">
@@ -12420,12 +12424,19 @@ exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
   \\"type\\": \\"STATIC_LIST\\",
   \\"required\\": false,
   \\"values\\": [
-    \\"red\\",
-    \\"green\\",
-    \\"blue\\",
-    \\"yellow\\",
-    \\"pink\\"
-  ]
+    \\"Red\\",
+    \\"Green\\",
+    \\"LightBlue\\",
+    \\"Yellow\\",
+    \\"Pink\\"
+  ],
+  \\"names\\": {
+    \\"red\\": \\"Red\\",
+    \\"green\\": \\"Green\\",
+    \\"lightblue\\": \\"Light Blue\\",
+    \\"yellow\\": \\"Yellow\\",
+    \\"pink\\": \\"Rosé\\"
+  }
 }
 </code>
 </pre>
@@ -12546,7 +12557,8 @@ exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
 <li><strong>name</strong>: <em>required (string)</em></li>
 <li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li>
 <li><strong>required</strong>: <em>required (boolean - default: false)</em></li>
-<li><strong>values</strong>: <em>(array of )</em></li>
+<li><strong>values</strong>: <em>(array of )</em><p>Only relevant when type is STATIC_LIST. These values are immutable. Their UI representation can be looked up in the <code>names</code> object below.</p></li>
+<li><strong>names</strong>: <em>(names)</em><p>Only relevant when type is STATIC_LIST. Each STATIC_LIST entry has an immutable <code>value</code> which is stored with the worklog, and a <code>name</code> that is shown in the UI. The <code>name</code> can be changed.</p><ul></ul></li>
 </ul>
 <p><strong>Example</strong>:</p>
 <div class=\\"examples\\">
@@ -12558,12 +12570,19 @@ exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
   \\"type\\": \\"STATIC_LIST\\",
   \\"required\\": false,
   \\"values\\": [
-    \\"red\\",
-    \\"green\\",
-    \\"blue\\",
-    \\"yellow\\",
-    \\"pink\\"
-  ]
+    \\"Red\\",
+    \\"Green\\",
+    \\"LightBlue\\",
+    \\"Yellow\\",
+    \\"Pink\\"
+  ],
+  \\"names\\": {
+    \\"red\\": \\"Red\\",
+    \\"green\\": \\"Green\\",
+    \\"lightblue\\": \\"Light Blue\\",
+    \\"yellow\\": \\"Yellow\\",
+    \\"pink\\": \\"Rosé\\"
+  }
 }
 </code>
 </pre>
@@ -12670,11 +12689,11 @@ exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
   \\"type\\": \\"STATIC_LIST\\",
   \\"required\\": false,
   \\"values\\": [
-    \\"red\\",
-    \\"green\\",
-    \\"blue\\",
-    \\"yellow\\",
-    \\"pink\\"
+    \\"Red\\",
+    \\"Green\\",
+    \\"Light Blue\\",
+    \\"Yellow\\",
+    \\"Pink\\"
   ]
 }
 </code>
@@ -12694,7 +12713,8 @@ exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
 <li><strong>name</strong>: <em>required (string)</em></li>
 <li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li>
 <li><strong>required</strong>: <em>required (boolean - default: false)</em></li>
-<li><strong>values</strong>: <em>(array of )</em></li>
+<li><strong>values</strong>: <em>(array of )</em><p>Only relevant when type is STATIC_LIST. These values are immutable. Their UI representation can be looked up in the <code>names</code> object below.</p></li>
+<li><strong>names</strong>: <em>(names)</em><p>Only relevant when type is STATIC_LIST. Each STATIC_LIST entry has an immutable <code>value</code> which is stored with the worklog, and a <code>name</code> that is shown in the UI. The <code>name</code> can be changed.</p><ul></ul></li>
 </ul>
 <p><strong>Example</strong>:</p>
 <div class=\\"examples\\">
@@ -12706,12 +12726,19 @@ exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
   \\"type\\": \\"STATIC_LIST\\",
   \\"required\\": false,
   \\"values\\": [
-    \\"red\\",
-    \\"green\\",
-    \\"blue\\",
-    \\"yellow\\",
-    \\"pink\\"
-  ]
+    \\"Red\\",
+    \\"Green\\",
+    \\"LightBlue\\",
+    \\"Yellow\\",
+    \\"Pink\\"
+  ],
+  \\"names\\": {
+    \\"red\\": \\"Red\\",
+    \\"green\\": \\"Green\\",
+    \\"lightblue\\": \\"Light Blue\\",
+    \\"yellow\\": \\"Yellow\\",
+    \\"pink\\": \\"Rosé\\"
+  }
 }
 </code>
 </pre>
@@ -12840,11 +12867,11 @@ exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
   \\"type\\": \\"STATIC_LIST\\",
   \\"required\\": false,
   \\"values\\": [
-    \\"red\\",
-    \\"green\\",
-    \\"blue\\",
-    \\"yellow\\",
-    \\"pink\\"
+    \\"Red\\",
+    \\"Green\\",
+    \\"Light Blue\\",
+    \\"Yellow\\",
+    \\"Pink\\"
   ]
 }
 </code>
@@ -12864,7 +12891,8 @@ exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
 <li><strong>name</strong>: <em>required (string)</em></li>
 <li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li>
 <li><strong>required</strong>: <em>required (boolean - default: false)</em></li>
-<li><strong>values</strong>: <em>(array of )</em></li>
+<li><strong>values</strong>: <em>(array of )</em><p>Only relevant when type is STATIC_LIST. These values are immutable. Their UI representation can be looked up in the <code>names</code> object below.</p></li>
+<li><strong>names</strong>: <em>(names)</em><p>Only relevant when type is STATIC_LIST. Each STATIC_LIST entry has an immutable <code>value</code> which is stored with the worklog, and a <code>name</code> that is shown in the UI. The <code>name</code> can be changed.</p><ul></ul></li>
 </ul>
 <p><strong>Example</strong>:</p>
 <div class=\\"examples\\">
@@ -12876,12 +12904,19 @@ exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
   \\"type\\": \\"STATIC_LIST\\",
   \\"required\\": false,
   \\"values\\": [
-    \\"red\\",
-    \\"green\\",
-    \\"blue\\",
-    \\"yellow\\",
-    \\"pink\\"
-  ]
+    \\"Red\\",
+    \\"Green\\",
+    \\"LightBlue\\",
+    \\"Yellow\\",
+    \\"Pink\\"
+  ],
+  \\"names\\": {
+    \\"red\\": \\"Red\\",
+    \\"green\\": \\"Green\\",
+    \\"lightblue\\": \\"Light Blue\\",
+    \\"yellow\\": \\"Yellow\\",
+    \\"pink\\": \\"Rosé\\"
+  }
 }
 </code>
 </pre>
@@ -16178,7 +16213,8 @@ exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
 <div class=\\"resource_method_title\\">
 <span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span>
 <div class=\\"method_description\\">
-<p>Bulk create work attribute values for worklogs</p>
+<p>Bulk create work attribute values for worklogs.</p>
+<p>Note: This API only supports creating new work attribute values. Work attribute values can only be updated as part of the worklog.</p>
 <div class=\\"clearfix\\"></div>
 </div>
 </div>
@@ -16239,7 +16275,7 @@ exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
 <h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2>
 <p>Work attribute values have been created</p>
 <h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2>
-<p>Work attribute values cannot be created for some reasons</p>
+<p>Work attribute values cannot be created for some reasons, for example if the value is not valid for the type of the work attribute, or if the worklog already has a value for the specified attribute.</p>
 <h3>Body</h3>
 <p><strong>Media type</strong>: application/json</p>
 <p><strong>Type</strong>: object</p>
@@ -16344,7 +16380,7 @@ exports[`Tempo REST API Documentation formatted XML has not changed 1`] = `
 `;
 
 exports[`Tempo REST API Documentation has not changed 1`] = `
-"<!DOCTYPE HTML><html><head><title>REST API documentation</title><meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\"><meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=utf-8\\"><meta name=\\"generator\\" content=\\"https://github.com/raml2html/raml2html 7.5.0\\"><link rel=\\"stylesheet\\" href=\\"https://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css\\"><link rel=\\"stylesheet\\" href=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/styles/default.min.css\\"><script type=\\"text/javascript\\" src=\\"https://code.jquery.com/jquery-1.11.0.min.js\\"></script><script type=\\"text/javascript\\" src=\\"https://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js\\"></script><script type=\\"text/javascript\\" src=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/highlight.min.js\\"></script><script type=\\"text/javascript\\">
+"<!DOCTYPE HTML><html><head><title>REST API documentation</title><meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\"><meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=utf-8\\"><meta name=\\"generator\\" content=\\"https://github.com/raml2html/raml2html 7.7.0\\"><link rel=\\"stylesheet\\" href=\\"https://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css\\"><link rel=\\"stylesheet\\" href=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/styles/default.min.css\\"><script type=\\"text/javascript\\" src=\\"https://code.jquery.com/jquery-1.11.0.min.js\\"></script><script type=\\"text/javascript\\" src=\\"https://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js\\"></script><script type=\\"text/javascript\\" src=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/highlight.min.js\\"></script><script type=\\"text/javascript\\">
       $(document).ready(function() {
         $('.page-header pre code, .top-resource-description pre code').each(function(i, block) {
           hljs.highlightBlock(block);
@@ -16496,7 +16532,7 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
       .sg-nav__spacer {
         padding-top: 30px;
       }
-    </style><link href=\\"https://fonts.googleapis.com/css?family=Open+Sans:300,400,700\\" rel=\\"stylesheet\\"><link rel=\\"stylesheet\\" href=\\"main.css\\"></head><body data-spy=\\"scroll\\" data-target=\\"#sidebar\\"><article class=\\"sg\\"><nav class=\\"sg-section sg-section--nav\\" style=\\"overflow-y: auto;\\"><div class=\\"sg-nav\\"><img class=\\"sg-nav__logo\\" src=\\"logo.png\\" alt=\\"TEMPO REST API\\" height=\\"48\\"><div>REST API version 3</div><ul class=\\"sg-nav__links\\"><li class=\\"sg-nav__links__element\\"><a href=\\"#accounts\\">Accounts</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#account_categories\\">Account - Categories</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#account_category_types\\">Account - Category - Types</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#account_links\\">Account - Links</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#customers\\">Customers</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#holiday_schemes\\">Holiday Schemes</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#periods\\">Periods</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#permission_roles\\">Permission Roles</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#plans\\">Plans</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#programs\\">Programs</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#roles\\">Roles</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#teams\\">Teams</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#team_links\\">Team - Links</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#team_memberships\\">Team - Memberships</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#timesheet_approvals\\">Timesheet Approvals</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#user_schedule\\">User Schedule</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#work_attributes\\">Work Attributes</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#workload_schemes\\">Workload Schemes</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#worklogs\\">Worklogs</a></li></ul><div class=\\"sg-nav__spacer\\">Audit API</div><ul class=\\"sg-nav__links\\"><li class=\\"sg-nav__links__element\\"><a href=\\"https://tempo-io.github.io/tempo-audit-docs/\\">Endpoints</a></li></ul></div></nav><section class=\\"sg-section sg-section--main\\"><div class=\\"sg-content\\"><h1 class=\\"sg-h1\\">REST API documentation <small>version 3</small></h1><p class=\\"sg-p\\">https://api.tempo.io/core/{version}</p><p class=\\"sg-p\\"></p><h3>About the Tempo REST API</h3><p class=\\"sg-p\\"><strong>Version 3 of the Tempo REST API is available as of February 1st, 2019.</strong></p><p class=\\"sg-p\\"><strong>As of March 29th, 2019, version 2 has been decomissioned. Everyone using the API is encouraged to switch to version 3.</strong></p><p class=\\"sg-p\\"><strong>For more information, see <a href=\\"https://tempo-io.atlassian.net/wiki/spaces/CLOUDNEWS/pages/358810021/2018-12-07+Action+Required+for+API+Users+Jira+Cloud+Privacy+Updates\\">this announcement</a>.</strong></p><p class=\\"sg-p\\">The REST API is designed around a flexible and scalable architecture that will extend in lockstep with Tempo’s development.</p><p class=\\"sg-p\\">We encourage you to join our developer community on Slack at <a href=\\"https://www.tempo.io/developers\\">www.tempo.io/developers</a>, where you can get support from our internal experts and share best practices with other developers building with Tempo.</p><p class=\\"sg-p\\">If you have feedback or requests, you can also reach us through our <a href=\\"https://tempo-io.atlassian.net/servicedesk/customer/portal/6\\">Customer Support Portal</a>. You can find general product information in the <a href=\\"https://www.tempo.io/documentation\\">Tempo Help Center</a>.</p><h3>Changes from version 2</h3><h4>Privacy improvements</h4><p class=\\"sg-p\\">All APIs that previously used a username to identify users now use accountId instead. Field names in JSON documents have changed accordingly, for example <code>leadUsername</code> has been replaced with <code>leadAccountId</code>.</p><h4>Account contact</h4><p class=\\"sg-p\\">When creating an account, separate fields are used to identify the contact depending on whether the contact is a registered Jira user.</p><p class=\\"sg-p\\">The <code>contactAccountId</code> field is used to identify the contact if the contact is a registered Jira user. The <code>externalContactName</code> field is used if the contact is not a registered Jira user.</p><p class=\\"sg-p\\">In account responses, a new <code>type</code> field marks the contact as a Jira user (USER) or not (EXTERNAL).</p><h4>Team permission update</h4><p class=\\"sg-p\\">The API for updating team permissions has been removed.</p><h3>Using the REST API as an individual user</h3><p class=\\"sg-p\\">You can use the REST API to interact with the data your permissions give you access to. To do so, you will need to generate a Tempo OAuth 2.0 token.</p><p class=\\"sg-p\\">Go to <b>Tempo>Settings</b>, scroll down to <b>Data Access</b> and select <b>API integration</b>.</p><p class=\\"sg-p\\">Once you have a token, you need to use it inside the Authorization HTTP header. Ex:<pre>curl -v -H \\"Authorization: Bearer $token\\" \\"https://api.tempo.io/core/3/worklogs?...\\"</pre></p><h3>Using the REST API as an application developer</h3><p class=\\"sg-p\\">If you are building apps with Tempo, and have the required Tempo administrator permissions, you can quickly obtain the OAuth 2.0 credentials you need to retrieve an access token.</p><h4>Obtain your credentials</h4><p class=\\"sg-p\\">Go to <b>Tempo>Settings</b>, scroll down to <b>Data Access</b> and select <b>OAuth 2.0 authentication</b>.</p><p class=\\"sg-p\\">Enter a <i>Redirect URI</i> and specify the <i>Client type</i> and <i>Authorization grant type</i>. In most cases you will choose <i>Authorization code</i> as the Authorization grant type.</p><p class=\\"sg-p\\">Once you click <b>Add</b>, your Client ID and Client secret are generated and you can retrieve your access token.</p><h3>How to retrieve an access token for a user</h3><h4>Authorization grant type used is <i>authorization_code</i></h4><h5>Step 1</h5><p class=\\"sg-p\\">Obtain an authorization code against your JIRA Cloud instance :<pre>GET: https://{jira-cloud-instance-name}.atlassian.net/plugins/servlet/ac/io.tempo.jira/oauth-authorize/?client_id=$CLIENT_ID&redirect_uri=$REDIRECT_URI&access_type=tenant_user</pre></p><p class=\\"sg-p\\">Where <i>$CLIENT_ID</i> and <i>$REDIRECT_URI</i> match the one you generated in <b>Tempo > Settings > OAuth 2.0 Applications</b></p><p class=\\"sg-p\\">You will be asked to <b>authorize</b> or <b>deny</b> access to your Tempo data. Granting access redirects you to the configured <i>redirect URI</i> with a new query string parameter named <i>code</i> (this is the authorization code). Note that this authorization code expires quickly.</p><p class=\\"sg-p\\"><img src=\\"myapp-request-access.png\\" title=\\"MyApp Request Access\\"></p><h5>Step 2</h5><p class=\\"sg-p\\">Obtain an access token from Tempo by providing the <i>authorization code</i> to:<pre>POST: https://api.tempo.io/oauth/token/</pre>sending the following parameters using the \\"application/x-www-form-urlencoded\\" format:<pre>
+    </style><link href=\\"https://fonts.googleapis.com/css?family=Open+Sans:300,400,700\\" rel=\\"stylesheet\\"><link rel=\\"stylesheet\\" href=\\"main.css\\"></head><body data-spy=\\"scroll\\" data-target=\\"#sidebar\\"><article class=\\"sg\\"><nav class=\\"sg-section sg-section--nav\\" style=\\"overflow-y: auto;\\"><div class=\\"sg-nav\\"><img class=\\"sg-nav__logo\\" src=\\"logo.png\\" alt=\\"TEMPO REST API\\" height=\\"48\\"><div>REST API version 3</div><ul class=\\"sg-nav__links\\"><li class=\\"sg-nav__links__element\\"><a href=\\"#accounts\\">Accounts</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#account_categories\\">Account - Categories</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#account_category_types\\">Account - Category - Types</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#account_links\\">Account - Links</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#customers\\">Customers</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#holiday_schemes\\">Holiday Schemes</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#periods\\">Periods</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#permission_roles\\">Permission Roles</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#plans\\">Plans</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#programs\\">Programs</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#roles\\">Roles</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#teams\\">Teams</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#team_links\\">Team - Links</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#team_memberships\\">Team - Memberships</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#timesheet_approvals\\">Timesheet Approvals</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#user_schedule\\">User Schedule</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#work_attributes\\">Work Attributes</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#workload_schemes\\">Workload Schemes</a></li><li class=\\"sg-nav__links__element\\"><a href=\\"#worklogs\\">Worklogs</a></li></ul><div class=\\"sg-nav__spacer\\">Audit API</div><ul class=\\"sg-nav__links\\"><li class=\\"sg-nav__links__element\\"><a href=\\"https://tempo-io.github.io/tempo-audit-docs/\\">Endpoints</a></li></ul><div class=\\"sg-nav__spacer\\">Cost-Tracker API (Beta)</div><ul class=\\"sg-nav__links\\"><li class=\\"sg-nav__links__element\\"><a href=\\"https://apidocs.tempo.io/cost-tracker\\">Endpoints</a></li></ul><div class=\\"sg-nav__spacer\\">Jira Links API (Beta)</div><ul class=\\"sg-nav__links\\"><li class=\\"sg-nav__links__element\\"><a href=\\"https://apidocs.tempo.io/jira\\">Endpoints</a></li></ul></div></nav><section class=\\"sg-section sg-section--main\\"><div class=\\"sg-content\\"><h1 class=\\"sg-h1\\">REST API documentation <small>version 3</small></h1><p class=\\"sg-p\\">https://api.tempo.io/core/{version}</p><p class=\\"sg-p\\"></p><p class=\\"sg-p\\">We encourage you to join our developer community on Slack at <a href=\\"https://www.tempo.io/developers\\">www.tempo.io/developers</a>, where you can get support from our internal experts and share best practices with other developers building with Tempo.</p><p class=\\"sg-p\\">If you have feedback or requests, you can also reach us through our <a href=\\"https://tempo-io.atlassian.net/servicedesk/customer/portal/6\\">Customer Support Portal</a>. You can find general product information in the <a href=\\"https://www.tempo.io/documentation\\">Tempo Help Center</a>.</p><h3>Using the REST API as an individual user</h3><p class=\\"sg-p\\">You can use the REST API to interact with the data your permissions give you access to. To do so, you will need to generate a Tempo OAuth 2.0 token.</p><p class=\\"sg-p\\">Go to <b>Tempo>Settings</b>, scroll down to <b>Data Access</b> and select <b>API integration</b>.</p><p class=\\"sg-p\\">Once you have a token, you need to use it inside the Authorization HTTP header. Ex:<pre>curl -v -H \\"Authorization: Bearer $token\\" \\"https://api.tempo.io/core/3/worklogs?...\\"</pre></p><h3>Using the REST API as an application developer</h3><p class=\\"sg-p\\">If you are building apps with Tempo, and have the required Tempo administrator permissions, you can quickly obtain the OAuth 2.0 credentials you need to retrieve an access token.</p><h4>Obtain your credentials</h4><p class=\\"sg-p\\">Go to <b>Tempo>Settings</b>, scroll down to <b>Data Access</b> and select <b>OAuth 2.0 authentication</b>.</p><p class=\\"sg-p\\">Enter a <i>Redirect URI</i> and specify the <i>Client type</i> and <i>Authorization grant type</i>. In most cases you will choose <i>Authorization code</i> as the Authorization grant type.</p><p class=\\"sg-p\\">Once you click <b>Add</b>, your Client ID and Client secret are generated and you can retrieve your access token.</p><h3>How to retrieve an access token for a user</h3><h4>Authorization grant type used is <i>authorization_code</i></h4><h5>Step 1</h5><p class=\\"sg-p\\">Obtain an authorization code against your JIRA Cloud instance :<pre>GET: https://{jira-cloud-instance-name}.atlassian.net/plugins/servlet/ac/io.tempo.jira/oauth-authorize/?client_id=$CLIENT_ID&redirect_uri=$REDIRECT_URI&access_type=tenant_user</pre></p><p class=\\"sg-p\\">Where <i>$CLIENT_ID</i> and <i>$REDIRECT_URI</i> match the one you generated in <b>Tempo > Settings > OAuth 2.0 Applications</b></p><p class=\\"sg-p\\">You will be asked to <b>authorize</b> or <b>deny</b> access to your Tempo data. Granting access redirects you to the configured <i>redirect URI</i> with a new query string parameter named <i>code</i> (this is the authorization code). Note that this authorization code expires quickly.</p><p class=\\"sg-p\\"><img src=\\"myapp-request-access.png\\" title=\\"MyApp Request Access\\"></p><h5>Step 2</h5><p class=\\"sg-p\\">Obtain an access token from Tempo by providing the <i>authorization code</i> to:<pre>POST: https://api.tempo.io/oauth/token/</pre>sending the following parameters using the \\"application/x-www-form-urlencoded\\" format:<pre>
    grant_type = \\"authorization_code\\"
    client_id = $CLIENT_ID
    client_secret = $CLIENT_SECRET
@@ -16528,7 +16564,9 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
    client_secret = $CLIENT_SECRET
    token = $REFRESH_TOKEN
 }
-</pre></p><h3>API conventions</h3><h4>Identifying users</h4><p class=\\"sg-p\\">The Tempo REST API uses the Atlassian accountId to identify users. The accountId is an opaque identifier that uniquely identifies the user.</p><p class=\\"sg-p\\">The accountId of the current user can found using the <a href=\\"https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-group-Myself\\">Jira Myself API</a>.</p><p class=\\"sg-p\\">Information about a user, given the accountId, can be retrieved using the <a href=\\"https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-group-User\\">Jira User API</a>.</p><h4>Dates</h4><p class=\\"sg-p\\">The API uses strings to represent dates. Dates are formatted as <a href=\\"https://en.wikipedia.org/wiki/ISO_8601#Calendar_dates\\">ISO 8601 calendar dates</a> (YYYY-MM-DD). For example, March 29th, 2019 is formatted as 2019-03-29.</p><h4>Delete requests</h4><p class=\\"sg-p\\">On success, delete requests return a response with status code <a href=\\"https://httpstatuses.com/204\\">204 (No content)</a>. No payload body is included in the response.</p><p></p><ul><li><strong>version</strong>: <em>required (3)</em></li></ul><h2 class=\\"sg-h2\\" id=\\"accounts\\">Accounts</h2><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_accounts\\" href=\\"#panel_accounts\\"><span class=\\"parent\\"></span>/accounts</a> <span class=\\"methods\\"><span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_accounts\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Creates a new account.</p><p>Separate fields are used to identify the contact depending on whether the contact is a registered Jira user or not. The <code>contactAccountId</code> field is used to identify the contact if the contact is a registered Jira user. The <code>externalContactName</code> field is used if the contact is not a registered Jira user.</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#accounts_post_request\\" data-toggle=\\"tab\\">Request</a></li><li><a href=\\"#accounts_post_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#accounts_post_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"accounts_post_request\\"><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>key</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>status</strong>: <em>required (one of OPEN, CLOSED, ARCHIVED)</em></li><li><strong>leadAccountId</strong>: <em>required (string)</em></li><li><strong>contactAccountId</strong>: <em>(string)</em><p>accountId of the contact, if the contact is a registered Jira user</p></li><li><strong>externalContactName</strong>: <em>(string)</em><p>Name of the contact, if the contact is not a registered Jira user</p></li><li><strong>categoryKey</strong>: <em>(string)</em></li><li><strong>customerKey</strong>: <em>(string)</em></li><li><strong>monthlyBudget</strong>: <em>(number)</em></li><li><strong>global</strong>: <em>(boolean - default: false)</em></li></ul><p><strong>Examples</strong>:</p><div class=\\"examples\\"><p><strong>Jira user as contact</strong>:<br></p><pre><code>{
+</pre></p><h3>API conventions</h3><h4>Identifying users</h4><p class=\\"sg-p\\">The Tempo REST API uses the Atlassian accountId to identify users. The accountId is an opaque identifier that uniquely identifies the user.</p><p class=\\"sg-p\\">The accountId of the current user can found using the <a href=\\"https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-group-Myself\\">Jira Myself API</a>.</p><p class=\\"sg-p\\">Information about a user, given the accountId, can be retrieved using the <a href=\\"https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-group-User\\">Jira User API</a>.</p><h4>Dates</h4><p class=\\"sg-p\\">The API uses strings to represent dates. Dates are formatted as <a href=\\"https://en.wikipedia.org/wiki/ISO_8601#Calendar_dates\\">ISO 8601 calendar dates</a> (YYYY-MM-DD). For example, March 29th, 2019 is formatted as 2019-03-29.</p><h4>Delete requests</h4><p class=\\"sg-p\\">On success, delete requests return a response with status code <a href=\\"https://httpstatuses.com/204\\">204 (No content)</a>. No payload body is included in the response.</p><h4>Arrays</h4><p class=\\"sg-p\\">A few endpoints accept query parameters of type array. That is achieved by repeating the parameter multiple times, e.g. to get worklogs from three projects:<pre>
+.../worklogs?from=2020-01-01&to=2020-12-31&project=10100&project=10200&project=10300
+</pre></p><p></p><ul><li><strong>version</strong>: <em>required (3)</em></li></ul><h2 class=\\"sg-h2\\" id=\\"accounts\\">Accounts</h2><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_accounts\\" href=\\"#panel_accounts\\"><span class=\\"parent\\"></span>/accounts</a> <span class=\\"methods\\"><span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_accounts\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Creates a new account.</p><p>Separate fields are used to identify the contact depending on whether the contact is a registered Jira user or not. The <code>contactAccountId</code> field is used to identify the contact if the contact is a registered Jira user. The <code>externalContactName</code> field is used if the contact is not a registered Jira user.</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#accounts_post_request\\" data-toggle=\\"tab\\">Request</a></li><li><a href=\\"#accounts_post_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#accounts_post_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"accounts_post_request\\"><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>key</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>status</strong>: <em>required (one of OPEN, CLOSED, ARCHIVED)</em></li><li><strong>leadAccountId</strong>: <em>required (string)</em></li><li><strong>contactAccountId</strong>: <em>(string)</em><p>accountId of the contact, if the contact is a registered Jira user</p></li><li><strong>externalContactName</strong>: <em>(string)</em><p>Name of the contact, if the contact is not a registered Jira user</p></li><li><strong>categoryKey</strong>: <em>(string)</em></li><li><strong>customerKey</strong>: <em>(string)</em></li><li><strong>monthlyBudget</strong>: <em>(number)</em></li><li><strong>global</strong>: <em>(boolean - default: false)</em></li></ul><p><strong>Examples</strong>:</p><div class=\\"examples\\"><p><strong>Jira user as contact</strong>:<br></p><pre><code>{
   \\"key\\": \\"CLOUDBAY_DEVELOPMENT\\",
   \\"name\\": \\"Cloudbay: Development\\",
   \\"status\\": \\"OPEN\\",
@@ -19824,7 +19862,7 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
       \\"type\\": \\"WORKING_DAY\\"
     }
   ]
-}</code></pre></div><h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2><p>Client must be authenticated to access this resource.</p></div><div class=\\"tab-pane\\" id=\\"user_schedule__accountid__get_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div><h2 class=\\"sg-h2\\" id=\\"work_attributes\\">Work Attributes</h2><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_work_attributes\\" href=\\"#panel_work_attributes\\"><span class=\\"parent\\"></span>/work-attributes</a> <span class=\\"methods\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_work_attributes\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Retrieve all work attributes</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#work_attributes_get_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#work_attributes_get_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"work_attributes_get_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>List of all work attributes</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li><li><strong>results</strong>: <em>required (array of Work Attribute)</em><p><strong>Items</strong>: Work Attribute</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li><li><strong>required</strong>: <em>required (boolean - default: false)</em></li><li><strong>values</strong>: <em>(array of )</em></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+}</code></pre></div><h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2><p>Client must be authenticated to access this resource.</p></div><div class=\\"tab-pane\\" id=\\"user_schedule__accountid__get_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div><h2 class=\\"sg-h2\\" id=\\"work_attributes\\">Work Attributes</h2><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_work_attributes\\" href=\\"#panel_work_attributes\\"><span class=\\"parent\\"></span>/work-attributes</a> <span class=\\"methods\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_work_attributes\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Retrieve all work attributes</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#work_attributes_get_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#work_attributes_get_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"work_attributes_get_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>List of all work attributes</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>metadata</strong>: <em>required (metadata)</em><ul><li><strong>count</strong>: <em>required (integer)</em></li></ul></li><li><strong>results</strong>: <em>required (array of Work Attribute)</em><p><strong>Items</strong>: Work Attribute</p><div class=\\"items\\"><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li><li><strong>required</strong>: <em>required (boolean - default: false)</em></li><li><strong>values</strong>: <em>(array of )</em><p>Only relevant when type is STATIC_LIST. These values are immutable. Their UI representation can be looked up in the <code>names</code> object below.</p></li><li><strong>names</strong>: <em>(names)</em><p>Only relevant when type is STATIC_LIST. Each STATIC_LIST entry has an immutable <code>value</code> which is stored with the worklog, and a <code>name</code> that is shown in the UI. The <code>name</code> can be changed.</p><ul></ul></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
   \\"self\\": \\"https://api.tempo.io/core/3/work-attributes\\",
   \\"metadata\\": {
     \\"count\\": 2
@@ -19837,12 +19875,19 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
       \\"type\\": \\"STATIC_LIST\\",
       \\"required\\": false,
       \\"values\\": [
-        \\"red\\",
-        \\"green\\",
-        \\"blue\\",
-        \\"yellow\\",
-        \\"pink\\"
-      ]
+        \\"Red\\",
+        \\"Green\\",
+        \\"LightBlue\\",
+        \\"Yellow\\",
+        \\"Pink\\"
+      ],
+      \\"names\\": {
+        \\"Red\\": \\"Red\\",
+        \\"Green\\": \\"Green\\",
+        \\"LightBlue\\": \\"Light Blue\\",
+        \\"Yellow\\": \\"Yellow\\",
+        \\"Pink\\": \\"Rosé\\"
+      }
     },
     {
       \\"self\\": \\"https://api.tempo.io/core/3/work-attributes/_EXTERNALREF_\\",
@@ -19865,26 +19910,33 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
   \\"type\\": \\"STATIC_LIST\\",
   \\"required\\": false,
   \\"values\\": [
-    \\"red\\",
-    \\"green\\",
-    \\"blue\\",
-    \\"yellow\\",
-    \\"pink\\"
+    \\"Red\\",
+    \\"Green\\",
+    \\"Light Blue\\",
+    \\"Yellow\\",
+    \\"Pink\\"
   ]
 }
-</code></pre></div></div><div class=\\"tab-pane\\" id=\\"work_attributes_post_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>Work attribute has been successfully created</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li><li><strong>required</strong>: <em>required (boolean - default: false)</em></li><li><strong>values</strong>: <em>(array of )</em></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+</code></pre></div></div><div class=\\"tab-pane\\" id=\\"work_attributes_post_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>Work attribute has been successfully created</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li><li><strong>required</strong>: <em>required (boolean - default: false)</em></li><li><strong>values</strong>: <em>(array of )</em><p>Only relevant when type is STATIC_LIST. These values are immutable. Their UI representation can be looked up in the <code>names</code> object below.</p></li><li><strong>names</strong>: <em>(names)</em><p>Only relevant when type is STATIC_LIST. Each STATIC_LIST entry has an immutable <code>value</code> which is stored with the worklog, and a <code>name</code> that is shown in the UI. The <code>name</code> can be changed.</p><ul></ul></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
   \\"self\\": \\"https://api.tempo.io/core/3/work-attributes/_COLOR_\\",
   \\"key\\": \\"_COLOR_\\",
   \\"name\\": \\"Color\\",
   \\"type\\": \\"STATIC_LIST\\",
   \\"required\\": false,
   \\"values\\": [
-    \\"red\\",
-    \\"green\\",
-    \\"blue\\",
-    \\"yellow\\",
-    \\"pink\\"
-  ]
+    \\"Red\\",
+    \\"Green\\",
+    \\"LightBlue\\",
+    \\"Yellow\\",
+    \\"Pink\\"
+  ],
+  \\"names\\": {
+    \\"red\\": \\"Red\\",
+    \\"green\\": \\"Green\\",
+    \\"lightblue\\": \\"Light Blue\\",
+    \\"yellow\\": \\"Yellow\\",
+    \\"pink\\": \\"Rosé\\"
+  }
 }
 </code></pre></div><h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2><p>Work attribute cannot be created for some reasons</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
   \\"errors\\": [
@@ -19899,19 +19951,26 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
       \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
     }
   ]
-}</code></pre></div></div><div class=\\"tab-pane\\" id=\\"work_attributes_post_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_work_attributes__key_\\" href=\\"#panel_work_attributes__key_\\"><span class=\\"parent\\">/work-attributes</span>/{key}</a> <span class=\\"methods\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_work_attributes__key_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Retrieve an existing work attribute for the given key</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#work_attributes__key__get_request\\" data-toggle=\\"tab\\">Request</a></li><li><a href=\\"#work_attributes__key__get_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#work_attributes__key__get_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"work_attributes__key__get_request\\"><h3>URI Parameters</h3><ul><li><strong>key</strong>: <em>required (string)</em></li></ul></div><div class=\\"tab-pane\\" id=\\"work_attributes__key__get_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>Work attribute data of the given key</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li><li><strong>required</strong>: <em>required (boolean - default: false)</em></li><li><strong>values</strong>: <em>(array of )</em></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+}</code></pre></div></div><div class=\\"tab-pane\\" id=\\"work_attributes_post_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_work_attributes__key_\\" href=\\"#panel_work_attributes__key_\\"><span class=\\"parent\\">/work-attributes</span>/{key}</a> <span class=\\"methods\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_put\\">put <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span> <span class=\\"badge badge_delete\\">delete <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_work_attributes__key_\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_get\\">get <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Retrieve an existing work attribute for the given key</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#work_attributes__key__get_request\\" data-toggle=\\"tab\\">Request</a></li><li><a href=\\"#work_attributes__key__get_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#work_attributes__key__get_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"work_attributes__key__get_request\\"><h3>URI Parameters</h3><ul><li><strong>key</strong>: <em>required (string)</em></li></ul></div><div class=\\"tab-pane\\" id=\\"work_attributes__key__get_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>Work attribute data of the given key</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li><li><strong>required</strong>: <em>required (boolean - default: false)</em></li><li><strong>values</strong>: <em>(array of )</em><p>Only relevant when type is STATIC_LIST. These values are immutable. Their UI representation can be looked up in the <code>names</code> object below.</p></li><li><strong>names</strong>: <em>(names)</em><p>Only relevant when type is STATIC_LIST. Each STATIC_LIST entry has an immutable <code>value</code> which is stored with the worklog, and a <code>name</code> that is shown in the UI. The <code>name</code> can be changed.</p><ul></ul></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
   \\"self\\": \\"https://api.tempo.io/core/3/work-attributes/_COLOR_\\",
   \\"key\\": \\"_COLOR_\\",
   \\"name\\": \\"Color\\",
   \\"type\\": \\"STATIC_LIST\\",
   \\"required\\": false,
   \\"values\\": [
-    \\"red\\",
-    \\"green\\",
-    \\"blue\\",
-    \\"yellow\\",
-    \\"pink\\"
-  ]
+    \\"Red\\",
+    \\"Green\\",
+    \\"LightBlue\\",
+    \\"Yellow\\",
+    \\"Pink\\"
+  ],
+  \\"names\\": {
+    \\"red\\": \\"Red\\",
+    \\"green\\": \\"Green\\",
+    \\"lightblue\\": \\"Light Blue\\",
+    \\"yellow\\": \\"Yellow\\",
+    \\"pink\\": \\"Rosé\\"
+  }
 }
 </code></pre></div><h2>HTTP status code <a href=\\"http://httpstatus.es/401\\" target=\\"_blank\\">401</a></h2><p>Client must be authenticated to access this resource.</p><h2>HTTP status code <a href=\\"http://httpstatus.es/403\\" target=\\"_blank\\">403</a></h2><p>Authenticated user is missing permission to fulfill the request</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
   \\"errors\\": [
@@ -19932,26 +19991,33 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
   \\"type\\": \\"STATIC_LIST\\",
   \\"required\\": false,
   \\"values\\": [
-    \\"red\\",
-    \\"green\\",
-    \\"blue\\",
-    \\"yellow\\",
-    \\"pink\\"
+    \\"Red\\",
+    \\"Green\\",
+    \\"Light Blue\\",
+    \\"Yellow\\",
+    \\"Pink\\"
   ]
 }
-</code></pre></div></div><div class=\\"tab-pane\\" id=\\"work_attributes__key__put_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>Work attribute data of the given key</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li><li><strong>required</strong>: <em>required (boolean - default: false)</em></li><li><strong>values</strong>: <em>(array of )</em></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+</code></pre></div></div><div class=\\"tab-pane\\" id=\\"work_attributes__key__put_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>Work attribute data of the given key</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li><li><strong>required</strong>: <em>required (boolean - default: false)</em></li><li><strong>values</strong>: <em>(array of )</em><p>Only relevant when type is STATIC_LIST. These values are immutable. Their UI representation can be looked up in the <code>names</code> object below.</p></li><li><strong>names</strong>: <em>(names)</em><p>Only relevant when type is STATIC_LIST. Each STATIC_LIST entry has an immutable <code>value</code> which is stored with the worklog, and a <code>name</code> that is shown in the UI. The <code>name</code> can be changed.</p><ul></ul></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
   \\"self\\": \\"https://api.tempo.io/core/3/work-attributes/_COLOR_\\",
   \\"key\\": \\"_COLOR_\\",
   \\"name\\": \\"Color\\",
   \\"type\\": \\"STATIC_LIST\\",
   \\"required\\": false,
   \\"values\\": [
-    \\"red\\",
-    \\"green\\",
-    \\"blue\\",
-    \\"yellow\\",
-    \\"pink\\"
-  ]
+    \\"Red\\",
+    \\"Green\\",
+    \\"LightBlue\\",
+    \\"Yellow\\",
+    \\"Pink\\"
+  ],
+  \\"names\\": {
+    \\"red\\": \\"Red\\",
+    \\"green\\": \\"Green\\",
+    \\"lightblue\\": \\"Light Blue\\",
+    \\"yellow\\": \\"Yellow\\",
+    \\"pink\\": \\"Rosé\\"
+  }
 }
 </code></pre></div><h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2><p>Work attribute cannot be updated for some reasons</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
   \\"errors\\": [
@@ -19979,26 +20045,33 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
   \\"type\\": \\"STATIC_LIST\\",
   \\"required\\": false,
   \\"values\\": [
-    \\"red\\",
-    \\"green\\",
-    \\"blue\\",
-    \\"yellow\\",
-    \\"pink\\"
+    \\"Red\\",
+    \\"Green\\",
+    \\"Light Blue\\",
+    \\"Yellow\\",
+    \\"Pink\\"
   ]
 }
-</code></pre></div></div><div class=\\"tab-pane\\" id=\\"work_attributes__key__put_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>Work attribute data of the given key</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li><li><strong>required</strong>: <em>required (boolean - default: false)</em></li><li><strong>values</strong>: <em>(array of )</em></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+</code></pre></div></div><div class=\\"tab-pane\\" id=\\"work_attributes__key__put_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/200\\" target=\\"_blank\\">200</a></h2><p>Work attribute data of the given key</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>self</strong>: <em>required (string)</em></li><li><strong>key</strong>: <em>required (string)</em></li><li><strong>name</strong>: <em>required (string)</em></li><li><strong>type</strong>: <em>required (one of CHECKBOX, INPUT_FIELD, INPUT_NUMERIC, STATIC_LIST)</em></li><li><strong>required</strong>: <em>required (boolean - default: false)</em></li><li><strong>values</strong>: <em>(array of )</em><p>Only relevant when type is STATIC_LIST. These values are immutable. Their UI representation can be looked up in the <code>names</code> object below.</p></li><li><strong>names</strong>: <em>(names)</em><p>Only relevant when type is STATIC_LIST. Each STATIC_LIST entry has an immutable <code>value</code> which is stored with the worklog, and a <code>name</code> that is shown in the UI. The <code>name</code> can be changed.</p><ul></ul></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
   \\"self\\": \\"https://api.tempo.io/core/3/work-attributes/_COLOR_\\",
   \\"key\\": \\"_COLOR_\\",
   \\"name\\": \\"Color\\",
   \\"type\\": \\"STATIC_LIST\\",
   \\"required\\": false,
   \\"values\\": [
-    \\"red\\",
-    \\"green\\",
-    \\"blue\\",
-    \\"yellow\\",
-    \\"pink\\"
-  ]
+    \\"Red\\",
+    \\"Green\\",
+    \\"LightBlue\\",
+    \\"Yellow\\",
+    \\"Pink\\"
+  ],
+  \\"names\\": {
+    \\"red\\": \\"Red\\",
+    \\"green\\": \\"Green\\",
+    \\"lightblue\\": \\"Light Blue\\",
+    \\"yellow\\": \\"Yellow\\",
+    \\"pink\\": \\"Rosé\\"
+  }
 }
 </code></pre></div><h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2><p>Work attribute cannot be updated for some reasons</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
   \\"errors\\": [
@@ -20823,7 +20896,7 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
       \\"message\\": \\"The logged-in-user does not have required permission to view this data\\"
     }
   ]
-}</code></pre></div></div><div class=\\"tab-pane\\" id=\\"worklogs_user__accountid__get_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_worklogs_work_attribute_values\\" href=\\"#panel_worklogs_work_attribute_values\\"><span class=\\"parent\\">/worklogs</span>/work-attribute-values</a> <span class=\\"methods\\"><span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_worklogs_work_attribute_values\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Bulk create work attribute values for worklogs</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#worklogs_work_attribute_values_post_request\\" data-toggle=\\"tab\\">Request</a></li><li><a href=\\"#worklogs_work_attribute_values_post_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#worklogs_work_attribute_values_post_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"worklogs_work_attribute_values_post_request\\"><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>tempoWorklogId</strong>: <em>required (integer)</em></li><li><strong>attributeValues</strong>: <em>required (string)</em></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>[
+}</code></pre></div></div><div class=\\"tab-pane\\" id=\\"worklogs_user__accountid__get_securedby\\"><h1>Secured by OAuth 2.0</h1><h3>Headers</h3><ul><li><strong>Authorization</strong>: <em>required (string)</em><p>Used to send a valid OAuth 2 token : \\"Authorization: Bearer \${token}\\"</p></li></ul></div></div><div class=\\"clearfix\\"></div></div></div></div></div></div></div><div class=\\"panel panel-default\\"><div class=\\"panel-heading\\"><a data-toggle=\\"collapse\\" data-target=\\"#panel_worklogs_work_attribute_values\\" href=\\"#panel_worklogs_work_attribute_values\\"><span class=\\"parent\\">/worklogs</span>/work-attribute-values</a> <span class=\\"methods\\"><span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span></span></div><div class=\\"panel-group\\"><div id=\\"panel_worklogs_work_attribute_values\\" class=\\"panel-collapse collapse\\" style=\\"height:auto\\"><div class=\\"panel-body\\"><div class=\\"list-group\\"><div class=\\"list-group-item\\"><div class=\\"resource_method_title\\"><span class=\\"badge badge_post\\">post <span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span></span><div class=\\"method_description\\"><p>Bulk create work attribute values for worklogs.</p><p>Note: This API only supports creating new work attribute values. Work attribute values can only be updated as part of the worklog.</p><div class=\\"clearfix\\"></div></div></div><div class=\\"alert alert-warning\\"><span class=\\"glyphicon glyphicon-lock\\" title=\\"Authentication required\\"></span> Secured by <b>OAuth 2.0</b><p>Tempo supports OAuth 2.0 for authenticating all API requests.</p></div><ul class=\\"nav nav-tabs\\"><li class=\\"active\\"><a href=\\"#worklogs_work_attribute_values_post_request\\" data-toggle=\\"tab\\">Request</a></li><li><a href=\\"#worklogs_work_attribute_values_post_response\\" data-toggle=\\"tab\\">Response</a></li><li><a href=\\"#worklogs_work_attribute_values_post_securedby\\" data-toggle=\\"tab\\">Security</a></li></ul><div class=\\"tab-content\\"><div class=\\"tab-pane active\\" id=\\"worklogs_work_attribute_values_post_request\\"><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>tempoWorklogId</strong>: <em>required (integer)</em></li><li><strong>attributeValues</strong>: <em>required (string)</em></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>[
   {
     \\"tempoWorklogId\\": 10100,
     \\"attributeValues\\": [
@@ -20847,7 +20920,7 @@ exports[`Tempo REST API Documentation has not changed 1`] = `
     ]
   }
 ]
-</code></pre></div></div><div class=\\"tab-pane\\" id=\\"worklogs_work_attribute_values_post_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2><p>Work attribute values have been created</p><h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2><p>Work attribute values cannot be created for some reasons</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
+</code></pre></div></div><div class=\\"tab-pane\\" id=\\"worklogs_work_attribute_values_post_response\\"><h2>HTTP status code <a href=\\"http://httpstatus.es/204\\" target=\\"_blank\\">204</a></h2><p>Work attribute values have been created</p><h2>HTTP status code <a href=\\"http://httpstatus.es/400\\" target=\\"_blank\\">400</a></h2><p>Work attribute values cannot be created for some reasons, for example if the value is not valid for the type of the work attribute, or if the worklog already has a value for the specified attribute.</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>errors</strong>: <em>required (array of items)</em><p><strong>Items</strong>: items</p><div class=\\"items\\"><ul><li><strong>message</strong>: <em>required (string)</em></li></ul></div></li></ul><p><strong>Example</strong>:</p><div class=\\"examples\\"><pre><code>{
   \\"errors\\": [
     {
       \\"message\\": \\"Invalid work attribute value\\"
@@ -20992,7 +21065,7 @@ Array [
   "Retrieve all worklogs associated to the given project key",
   "",
   "Retrieve all worklogs associated to the given user",
-  "Bulk create work attribute values for worklogs",
+  "Bulk create work attribute values for worklogs.Note: This API only supports creating new work attribute values. Work attribute values can only be updated as part of the worklog.",
 ]
 `;
 

--- a/tests/tempoDocumentation.test.ts
+++ b/tests/tempoDocumentation.test.ts
@@ -1,8 +1,9 @@
 import axios from 'axios';
+import { JSDOM } from 'jsdom';
 import format = require('xml-formatter');
 
 let responseData = '<html lang="en-us"></html>';
-let htmlDoc: Document = new Document();
+let htmlDoc: Document = new JSDOM(responseData).window.document;
 
 // This test is used to identify whether the documentation on Tempo's
 // website has updated. If the test fails, that means there must have been
@@ -10,14 +11,13 @@ let htmlDoc: Document = new Document();
 describe('Tempo REST API Documentation', () => {
   beforeAll(async () => {
     const response = await axios.get(
-      'https://tempo-io.github.io/tempo-api-docs/',
+      'https://apidocs.tempo.io/',
       {
         responseType: 'text',
       },
     );
     responseData = response.data;
-    const parser = new DOMParser();
-    htmlDoc = parser.parseFromString(responseData, 'text/html');
+    htmlDoc = new JSDOM(responseData).window.document;
   });
 
   it('has not changed', () => {


### PR DESCRIPTION
* Updated type definitions to reflect apidocs.tempo.io documentation, including:
  * `project` is now a valid query parameter for querying `/workings` (i.e. `worklogs.get()`)
  * WorkAttributes now include `names` for `STATIC_LIST` field types, which is a mapping of values to value-labels that are displayed in Tempo's UI.
* Fixed `tests/tempoDocumentation.test.ts`
  * The first issue was that Tempo's documentation website has changed from `https://tempo-io.github.io/tempo-api-docs/` to `https://apidocs.tempo.io/`.
  * The second issue was that jest no longer allows network requests from localhost, probably because Tempo's new host has a different CORS policy. To solve that we've switched the test environment to node in `jestconfig.json`.
  * And finally, because the test environment changed, we are not able to use DOM library functions/objects such as `Document` and `DOMParser`. This was fixed by using JSDom.
* Updated devDependencies via `npm update`.