### PR TITLE
NPM Update (axios + devDependencies)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "4.4.1",
       "license": "MIT",
       "dependencies": {
-        "axios": "^0.21.1"
+        "axios": "^0.21.3"
       },
       "devDependencies": {
         "@types/jest": "^27.0.1",
         "@types/jsdom": "^16.2.13",
-        "@types/node": "^16.7.6",
-        "@typescript-eslint/eslint-plugin": "^4.29.3",
-        "@typescript-eslint/parser": "^4.29.3",
+        "@types/node": "^16.7.10",
+        "@typescript-eslint/eslint-plugin": "^4.30.0",
+        "@typescript-eslint/parser": "^4.30.0",
         "codecov": "^3.8.3",
         "eslint": "^7.32.0",
         "eslint-config-airbnb-base": "^14.2.1",
@@ -25,7 +25,7 @@
         "jest": "^27.1.0",
         "jsdom": "^17.0.0",
         "ts-jest": "^27.0.5",
-        "typedoc": "^0.21.8",
+        "typedoc": "^0.21.9",
         "typescript": "^4.4.2",
         "xml-formatter": "^2.4.0"
       }
@@ -1160,9 +1160,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.7.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.6.tgz",
-      "integrity": "sha512-VESVNFoa/ahYA62xnLBjo5ur6gPsgEE5cNRy8SrdnkZ2nwJSW0kJ4ufbFr2zuU9ALtHM8juY53VcRoTA7htXSg==",
+      "version": "16.7.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.10.tgz",
+      "integrity": "sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA==",
       "dev": true
     },
     "node_modules/@types/parse5": {
@@ -1205,13 +1205,13 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.29.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.3.tgz",
-      "integrity": "sha512-tBgfA3K/3TsZY46ROGvoRxQr1wBkclbVqRQep97MjVHJzcRBURRY3sNFqLk0/Xr//BY5hM9H2p/kp+6qim85SA==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.30.0.tgz",
+      "integrity": "sha512-NgAnqk55RQ/SD+tZFD9aPwNSeHmDHHe5rtUyhIq0ZeCWZEvo4DK9rYz7v9HDuQZFvn320Ot+AikaCKMFKLlD0g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.29.3",
-        "@typescript-eslint/scope-manager": "4.29.3",
+        "@typescript-eslint/experimental-utils": "4.30.0",
+        "@typescript-eslint/scope-manager": "4.30.0",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.1.0",
@@ -1236,15 +1236,15 @@
       }
     },
     "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.29.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.3.tgz",
-      "integrity": "sha512-ffIvbytTVWz+3keg+Sy94FG1QeOvmV9dP2YSdLFHw/ieLXWCa3U1TYu8IRCOpMv2/SPS8XqhM1+ou1YHsdzKrg==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.30.0.tgz",
+      "integrity": "sha512-K8RNIX9GnBsv5v4TjtwkKtqMSzYpjqAQg/oSphtxf3xxdt6T0owqnpojztjjTcatSteH3hLj3t/kklKx87NPqw==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.29.3",
-        "@typescript-eslint/types": "4.29.3",
-        "@typescript-eslint/typescript-estree": "4.29.3",
+        "@typescript-eslint/scope-manager": "4.30.0",
+        "@typescript-eslint/types": "4.30.0",
+        "@typescript-eslint/typescript-estree": "4.30.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -1278,14 +1278,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "4.29.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.3.tgz",
-      "integrity": "sha512-jrHOV5g2u8ROghmspKoW7pN8T/qUzk0+DITun0MELptvngtMrwUJ1tv5zMI04CYVEUsSrN4jV7AKSv+I0y0EfQ==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.30.0.tgz",
+      "integrity": "sha512-HJ0XuluSZSxeboLU7Q2VQ6eLlCwXPBOGnA7CqgBnz2Db3JRQYyBDJgQnop6TZ+rsbSx5gEdWhw4rE4mDa1FnZg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "4.29.3",
-        "@typescript-eslint/types": "4.29.3",
-        "@typescript-eslint/typescript-estree": "4.29.3",
+        "@typescript-eslint/scope-manager": "4.30.0",
+        "@typescript-eslint/types": "4.30.0",
+        "@typescript-eslint/typescript-estree": "4.30.0",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1305,13 +1305,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.29.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.3.tgz",
-      "integrity": "sha512-x+w8BLXO7iWPkG5mEy9bA1iFRnk36p/goVlYobVWHyDw69YmaH9q6eA+Fgl7kYHmFvWlebUTUfhtIg4zbbl8PA==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.30.0.tgz",
+      "integrity": "sha512-VJ/jAXovxNh7rIXCQbYhkyV2Y3Ac/0cVHP/FruTJSAUUm4Oacmn/nkN5zfWmWFEanN4ggP0vJSHOeajtHq3f8A==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.29.3",
-        "@typescript-eslint/visitor-keys": "4.29.3"
+        "@typescript-eslint/types": "4.30.0",
+        "@typescript-eslint/visitor-keys": "4.30.0"
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -1322,9 +1322,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "4.29.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.3.tgz",
-      "integrity": "sha512-s1eV1lKNgoIYLAl1JUba8NhULmf+jOmmeFO1G5MN/RBCyyzg4TIOfIOICVNC06lor+Xmy4FypIIhFiJXOknhIg==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.30.0.tgz",
+      "integrity": "sha512-YKldqbNU9K4WpTNwBqtAerQKLLW/X2A/j4yw92e3ZJYLx+BpKLeheyzoPfzIXHfM8BXfoleTdiYwpsvVPvHrDw==",
       "dev": true,
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -1335,13 +1335,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.29.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.3.tgz",
-      "integrity": "sha512-45oQJA0bxna4O5TMwz55/TpgjX1YrAPOI/rb6kPgmdnemRZx/dB0rsx+Ku8jpDvqTxcE1C/qEbVHbS3h0hflag==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.30.0.tgz",
+      "integrity": "sha512-6WN7UFYvykr/U0Qgy4kz48iGPWILvYL34xXJxvDQeiRE018B7POspNRVtAZscWntEPZpFCx4hcz/XBT+erenfg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.29.3",
-        "@typescript-eslint/visitor-keys": "4.29.3",
+        "@typescript-eslint/types": "4.30.0",
+        "@typescript-eslint/visitor-keys": "4.30.0",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -1362,12 +1362,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.29.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.3.tgz",
-      "integrity": "sha512-MGGfJvXT4asUTeVs0Q2m+sY63UsfnA+C/FDgBKV3itLBmM9H0u+URcneePtkd0at1YELmZK6HSolCqM4Fzs6yA==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.30.0.tgz",
+      "integrity": "sha512-pNaaxDt/Ol/+JZwzP7MqWc8PJQTUhZwoee/PVlQ+iYoYhagccvoHnC9e4l+C/krQYYkENxznhVSDwClIbZVxRw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.29.3",
+        "@typescript-eslint/types": "4.30.0",
         "eslint-visitor-keys": "^2.0.0"
       },
       "engines": {
@@ -1604,11 +1604,11 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.3.tgz",
+      "integrity": "sha512-JtoZ3Ndke/+Iwt5n+BgSli/3idTvpt5OjKyoCmz4LX5+lPiY5l7C1colYezhlxThjNa/NhngCUWZSZFypIFuaA==",
       "dependencies": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/babel-jest": {
@@ -2923,9 +2923,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
-      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
+      "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==",
       "funding": [
         {
           "type": "individual",
@@ -6291,9 +6291,9 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.21.8",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.8.tgz",
-      "integrity": "sha512-uO2UR71+UjskIR1dNsNS/t54Ffi4F+MTwKI4REILCKGztpj7GyBaq3wVr5hqKrKlcs9e4qeBHlVnDJ2WiCNq1A==",
+      "version": "0.21.9",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.9.tgz",
+      "integrity": "sha512-VRo7aII4bnYaBBM1lhw4bQFmUcDQV8m8tqgjtc7oXl87jc1Slbhfw2X5MccfcR2YnEClHDWgsiQGgNB8KJXocA==",
       "dev": true,
       "dependencies": {
         "glob": "^7.1.7",
@@ -7597,9 +7597,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.7.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.6.tgz",
-      "integrity": "sha512-VESVNFoa/ahYA62xnLBjo5ur6gPsgEE5cNRy8SrdnkZ2nwJSW0kJ4ufbFr2zuU9ALtHM8juY53VcRoTA7htXSg==",
+      "version": "16.7.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.10.tgz",
+      "integrity": "sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA==",
       "dev": true
     },
     "@types/parse5": {
@@ -7642,13 +7642,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.29.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.3.tgz",
-      "integrity": "sha512-tBgfA3K/3TsZY46ROGvoRxQr1wBkclbVqRQep97MjVHJzcRBURRY3sNFqLk0/Xr//BY5hM9H2p/kp+6qim85SA==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.30.0.tgz",
+      "integrity": "sha512-NgAnqk55RQ/SD+tZFD9aPwNSeHmDHHe5rtUyhIq0ZeCWZEvo4DK9rYz7v9HDuQZFvn320Ot+AikaCKMFKLlD0g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.29.3",
-        "@typescript-eslint/scope-manager": "4.29.3",
+        "@typescript-eslint/experimental-utils": "4.30.0",
+        "@typescript-eslint/scope-manager": "4.30.0",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.1.0",
@@ -7657,15 +7657,15 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.29.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.3.tgz",
-      "integrity": "sha512-ffIvbytTVWz+3keg+Sy94FG1QeOvmV9dP2YSdLFHw/ieLXWCa3U1TYu8IRCOpMv2/SPS8XqhM1+ou1YHsdzKrg==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.30.0.tgz",
+      "integrity": "sha512-K8RNIX9GnBsv5v4TjtwkKtqMSzYpjqAQg/oSphtxf3xxdt6T0owqnpojztjjTcatSteH3hLj3t/kklKx87NPqw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.29.3",
-        "@typescript-eslint/types": "4.29.3",
-        "@typescript-eslint/typescript-estree": "4.29.3",
+        "@typescript-eslint/scope-manager": "4.30.0",
+        "@typescript-eslint/types": "4.30.0",
+        "@typescript-eslint/typescript-estree": "4.30.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -7682,41 +7682,41 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.29.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.3.tgz",
-      "integrity": "sha512-jrHOV5g2u8ROghmspKoW7pN8T/qUzk0+DITun0MELptvngtMrwUJ1tv5zMI04CYVEUsSrN4jV7AKSv+I0y0EfQ==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.30.0.tgz",
+      "integrity": "sha512-HJ0XuluSZSxeboLU7Q2VQ6eLlCwXPBOGnA7CqgBnz2Db3JRQYyBDJgQnop6TZ+rsbSx5gEdWhw4rE4mDa1FnZg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.29.3",
-        "@typescript-eslint/types": "4.29.3",
-        "@typescript-eslint/typescript-estree": "4.29.3",
+        "@typescript-eslint/scope-manager": "4.30.0",
+        "@typescript-eslint/types": "4.30.0",
+        "@typescript-eslint/typescript-estree": "4.30.0",
         "debug": "^4.3.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.29.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.3.tgz",
-      "integrity": "sha512-x+w8BLXO7iWPkG5mEy9bA1iFRnk36p/goVlYobVWHyDw69YmaH9q6eA+Fgl7kYHmFvWlebUTUfhtIg4zbbl8PA==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.30.0.tgz",
+      "integrity": "sha512-VJ/jAXovxNh7rIXCQbYhkyV2Y3Ac/0cVHP/FruTJSAUUm4Oacmn/nkN5zfWmWFEanN4ggP0vJSHOeajtHq3f8A==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.29.3",
-        "@typescript-eslint/visitor-keys": "4.29.3"
+        "@typescript-eslint/types": "4.30.0",
+        "@typescript-eslint/visitor-keys": "4.30.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.29.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.3.tgz",
-      "integrity": "sha512-s1eV1lKNgoIYLAl1JUba8NhULmf+jOmmeFO1G5MN/RBCyyzg4TIOfIOICVNC06lor+Xmy4FypIIhFiJXOknhIg==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.30.0.tgz",
+      "integrity": "sha512-YKldqbNU9K4WpTNwBqtAerQKLLW/X2A/j4yw92e3ZJYLx+BpKLeheyzoPfzIXHfM8BXfoleTdiYwpsvVPvHrDw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.29.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.3.tgz",
-      "integrity": "sha512-45oQJA0bxna4O5TMwz55/TpgjX1YrAPOI/rb6kPgmdnemRZx/dB0rsx+Ku8jpDvqTxcE1C/qEbVHbS3h0hflag==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.30.0.tgz",
+      "integrity": "sha512-6WN7UFYvykr/U0Qgy4kz48iGPWILvYL34xXJxvDQeiRE018B7POspNRVtAZscWntEPZpFCx4hcz/XBT+erenfg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.29.3",
-        "@typescript-eslint/visitor-keys": "4.29.3",
+        "@typescript-eslint/types": "4.30.0",
+        "@typescript-eslint/visitor-keys": "4.30.0",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -7725,12 +7725,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.29.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.3.tgz",
-      "integrity": "sha512-MGGfJvXT4asUTeVs0Q2m+sY63UsfnA+C/FDgBKV3itLBmM9H0u+URcneePtkd0at1YELmZK6HSolCqM4Fzs6yA==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.30.0.tgz",
+      "integrity": "sha512-pNaaxDt/Ol/+JZwzP7MqWc8PJQTUhZwoee/PVlQ+iYoYhagccvoHnC9e4l+C/krQYYkENxznhVSDwClIbZVxRw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.29.3",
+        "@typescript-eslint/types": "4.30.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -7896,11 +7896,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.3.tgz",
+      "integrity": "sha512-JtoZ3Ndke/+Iwt5n+BgSli/3idTvpt5OjKyoCmz4LX5+lPiY5l7C1colYezhlxThjNa/NhngCUWZSZFypIFuaA==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "babel-jest": {
@@ -8937,9 +8937,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
-      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
+      "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw=="
     },
     "form-data": {
       "version": "4.0.0",
@@ -11460,9 +11460,9 @@
       }
     },
     "typedoc": {
-      "version": "0.21.8",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.8.tgz",
-      "integrity": "sha512-uO2UR71+UjskIR1dNsNS/t54Ffi4F+MTwKI4REILCKGztpj7GyBaq3wVr5hqKrKlcs9e4qeBHlVnDJ2WiCNq1A==",
+      "version": "0.21.9",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.9.tgz",
+      "integrity": "sha512-VRo7aII4bnYaBBM1lhw4bQFmUcDQV8m8tqgjtc7oXl87jc1Slbhfw2X5MccfcR2YnEClHDWgsiQGgNB8KJXocA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.7",

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   "devDependencies": {
     "@types/jest": "^27.0.1",
     "@types/jsdom": "^16.2.13",
-    "@types/node": "^16.7.6",
-    "@typescript-eslint/eslint-plugin": "^4.29.3",
-    "@typescript-eslint/parser": "^4.29.3",
+    "@types/node": "^16.7.10",
+    "@typescript-eslint/eslint-plugin": "^4.30.0",
+    "@typescript-eslint/parser": "^4.30.0",
     "codecov": "^3.8.3",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.2.1",
@@ -47,11 +47,11 @@
     "jest": "^27.1.0",
     "jsdom": "^17.0.0",
     "ts-jest": "^27.0.5",
-    "typedoc": "^0.21.8",
+    "typedoc": "^0.21.9",
     "typescript": "^4.4.2",
     "xml-formatter": "^2.4.0"
   },
   "dependencies": {
-    "axios": "^0.21.1"
+    "axios": "^0.21.3"
   }
 }


### PR DESCRIPTION
Axios has two patch changes:

* https://github.com/axios/axios/releases/tag/v0.21.2
* https://github.com/axios/axios/releases/tag/0.21.3

None of the changes will impact node-tempo-client from what I can tell.

I will publish a new release of node-tempo-client a week from now, just to make sure axios hasn't broken anything.

